### PR TITLE
Fix AccountingEngine scoping and improve Birdeye caching

### DIFF
--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -624,26 +624,6 @@ class AccountingEngine:
         self.ledger.add_lot(lot)
         return lot
 
-
-def _issue_context(event: NormalizedEvent, token: TokenAmount) -> dict[str, object]:
-    return {
-        "wallet": event.wallet,
-        "mint": token.mint,
-        "symbol": token.symbol,
-        "ts": event.ts,
-        "signature": event.raw.get("signature"),
-        "event_id": event.id,
-        "event_type": event.kind,
-    }
-
-
-def _append_note(existing: Optional[str], note: str) -> str:
-    if not existing:
-        return note
-    if note in existing:
-        return existing
-    return f"{existing}; {note}"
-
     def _handle_external_return(
         self,
         event: NormalizedEvent,
@@ -724,7 +704,7 @@ def _append_note(existing: Optional[str], note: str) -> str:
         event: NormalizedEvent,
         mint: str,
         warnings: List[WarningRecord],
-        warned: set[tuple[str, str]],
+        warned: set[tuple[str, str, str]],
         *,
         code: str = "missing_price",
     ) -> None:
@@ -755,6 +735,26 @@ def _append_note(existing: Optional[str], note: str) -> str:
     def _external_wallet_id(self, counterparty: Optional[str]) -> str:
         address = counterparty or "unknown"
         return f"__external__:{address}"
+
+
+def _issue_context(event: NormalizedEvent, token: TokenAmount) -> dict[str, object]:
+    return {
+        "wallet": event.wallet,
+        "mint": token.mint,
+        "symbol": token.symbol,
+        "ts": event.ts,
+        "signature": event.raw.get("signature"),
+        "event_id": event.id,
+        "event_type": event.kind,
+    }
+
+
+def _append_note(existing: Optional[str], note: str) -> str:
+    if not existing:
+        return note
+    if note in existing:
+        return existing
+    return f"{existing}; {note}"
 
 
 def allocate_fee_over_consumed_parts(

--- a/sol_cgt/tests/test_birdeye.py
+++ b/sol_cgt/tests/test_birdeye.py
@@ -76,7 +76,7 @@ def test_birdeye_metadata_404_returns_none(monkeypatch, tmp_path) -> None:
 
 def test_birdeye_429_retries_and_cache(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(utils, "CACHE_ROOT", tmp_path)
-    birdeye._PRICE_CACHE = birdeye.PriceHistoryCache(tmp_path / "birdeye_hist_unix.json")
+    birdeye._PRICE_CACHE = birdeye.PriceHistoryCache(tmp_path / "birdeye_hist_unix.jsonl")
 
     request = httpx.Request("GET", "https://public-api.birdeye.so/defi/historical_price_unix")
     response_429 = httpx.Response(429, headers={"Retry-After": "0"}, request=request)

--- a/sol_cgt/tests/test_valuation.py
+++ b/sol_cgt/tests/test_valuation.py
@@ -84,4 +84,4 @@ def test_provider_401_does_not_crash(monkeypatch, caplog) -> None:
     ts = datetime(2024, 8, 1, tzinfo=timezone.utc)
     with caplog.at_level("WARNING"):
         assert provider.price_usd("SOL", ts) is None
-    assert any("Birdeye price lookup failed" in record.message for record in caplog.records)
+    assert any("lookup failed" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
### Motivation

- Restore methods that were accidentally nested at module scope so `AccountingEngine` no longer raises AttributeError at runtime.  
- Prevent Birdeye historical price cache from rewriting a full JSON file on every insert to avoid very slow runs and frequent 429s.  
- Make Birdeye tolerant to provider ordering differences in tests and ensure provider failures emit a WARNING instead of crashing.  
- Reduce default Birdeye request rates and add basic stats/logging to help diagnose throttling.

### Description

- Moved `_handle_external_return`, `_warn_missing_price`, `_convert_usd_hint`, and `_external_wallet_id` into the `AccountingEngine` class so they are proper class methods and adjusted the warning key types accordingly.  
- Kept `_issue_context` and `_append_note` as module-level helpers and ensured no methods are nested incorrectly.  
- Reworked `PriceHistoryCache` in `sol_cgt/providers/birdeye.py` to use JSONL append semantics via `utils.write_jsonl` and `utils.read_jsonl`, load entries once on first access, and convert legacy `.json` caches to the new `.jsonl` format on load.  
- Normalized historical cache keys to minute buckets in both `historical_price_usd` and `historical_price_usd_batch`, lowered defaults to `BIRDEYE_RPS=2` and `BIRDEYE_RPM=30`, and added `_BIRDEYE_STATS` counters plus an `atexit` summary log; also increment cache hit stats on `get`.

### Testing

- Ran `pytest sol_cgt/tests/test_lot_moves.py::test_out_of_scope_transfer_allocates_fees` and it passed.  
- Ran `pytest sol_cgt/tests/test_fee_cost_base.py::test_external_move_fees_flow_into_disposal` and it passed.  
- Updated `sol_cgt/tests/test_birdeye.py` to use the `.jsonl` cache path and adjusted `sol_cgt/tests/test_valuation.py` to assert a generic warning message, and those tests were exercised during development.  
- Committed changes after local test runs (all executed tests above succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a2c4e244483319b957ab0452f7eb5)