### PR TITLE
Route SOL/WSOL pricing to local cached daily SOL/USD table

### DIFF
--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -6,7 +6,7 @@ import logging
 import os
 import shutil
 import sys
-from datetime import timedelta, timezone
+from datetime import date, timedelta, timezone
 from decimal import Decimal
 from importlib import metadata
 from pathlib import Path
@@ -31,6 +31,7 @@ from . import utils
 from .utils import australian_financial_year_bounds, parse_local_date
 from .providers import birdeye as birdeye_provider
 from .providers import jupiter as jupiter_provider
+from .providers import sol_price_table
 
 _orig_option_init = typer.core.TyperOption.__init__
 logger = logging.getLogger(__name__)
@@ -209,6 +210,16 @@ def _resolve_fy_period(fy: Optional[str], fy_start: Optional[str], fy_end: Optio
     return None, None
 
 
+
+
+def _required_price_dates(events: list[NormalizedEvent], fy_period: Optional[utils.Period]) -> tuple[date, date] | None:
+    if fy_period is not None:
+        return utils.to_au_local(fy_period.start).date(), utils.to_au_local(fy_period.end).date()
+    if not events:
+        return None
+    days = [utils.to_au_local(ev.ts).date() for ev in events]
+    return min(days), max(days)
+
 def _summary_value(rows: list[dict[str, object]], key: str, default: object = 0) -> object:
     if rows:
         return rows[0].get(key, default)
@@ -330,6 +341,7 @@ def compute(
         "--max-backfill-days",
         help="Maximum days to backfill when auto-backfill is enabled",
     ),
+    use_birdeye: bool = typer.Option(False, "--use-birdeye/--no-use-birdeye", help="Enable optional Birdeye pricing for non-SOL tokens"),
 ) -> None:
     _configure_logging()
     parsed_wallets = _collect_wallets(wallet)
@@ -364,9 +376,16 @@ def compute(
         force_fetch=False,
     )
     _apply_kind_breakdown(kind_counts)
-    usd_provider = TimestampPriceProvider(api_key=settings.api_keys.birdeye)
+    price_dates = _required_price_dates(events, fy_period)
+    if price_dates is not None:
+        start_day, end_day = price_dates
+        cache_path = asyncio.run(sol_price_table.ensure_sol_usd_daily_prices(start_day, end_day))
+        rows, _, _ = sol_price_table.cache_stats(cache_path)
+        logger.info("SOL/USD daily price table ready path=%s start=%s end=%s rows=%s source=yahoo", cache_path, start_day.isoformat(), end_day.isoformat(), rows)
+    birdeye_key = settings.api_keys.birdeye if use_birdeye else None
+    usd_provider = TimestampPriceProvider(api_key=birdeye_key)
     price_provider = AudPriceProvider(
-        api_key=settings.api_keys.birdeye,
+        api_key=birdeye_key,
         fx_source=settings.fx_source,
         usd_provider=usd_provider,
     )

--- a/sol_cgt/pricing/__init__.py
+++ b/sol_cgt/pricing/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from .. import utils
-from ..providers import birdeye, fx_rates, kraken, rba_fx
+from ..providers import birdeye, fx_rates, rba_fx, sol_price_table
 
 WSOL_MINT = "So11111111111111111111111111111111111111112"
 USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
@@ -66,11 +66,7 @@ class TimestampPriceProvider:
             return Decimal("1")
         if mint == WSOL_MINT:
             date_local = utils.to_au_local(ts).date()
-            try:
-                return _run_async(kraken.get_sol_usd_close_for_date(date_local))
-            except Exception as exc:
-                LOGGER.warning("Kraken SOL/USD lookup failed for %s: %s", date_local.isoformat(), exc)
-                return None
+            return sol_price_table.get_sol_usd_close_for_date(date_local)
         bucket = _unix_minute_bucket(ts)
         cached = self.cache.get(mint, bucket)
         if cached is not None:
@@ -123,7 +119,8 @@ def _unix_minute_bucket(ts: datetime) -> int:
 
 
 def normalize_mint(mint: str) -> str:
-    if mint.upper() == "SOL":
+    upper = mint.upper()
+    if upper in {"SOL", "WSOL"} or mint == WSOL_MINT:
         return WSOL_MINT
     return mint
 

--- a/sol_cgt/providers/sol_price_table.py
+++ b/sol_cgt/providers/sol_price_table.py
@@ -1,0 +1,157 @@
+"""SOL/USD daily OHLC table provider with local CSV cache."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+import csv
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+
+
+LOGGER = logging.getLogger(__name__)
+YAHOO_DOWNLOAD_URL = "https://query1.finance.yahoo.com/v7/finance/download/SOL-USD"
+CACHE_PATH = Path(".sol_cgt_cache") / "prices" / "sol_usd_daily.csv"
+SOURCE = "yahoo"
+
+
+@dataclass(frozen=True)
+class SolDailyPrice:
+    day: date
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+    source: str = SOURCE
+
+
+def _cache_path() -> Path:
+    return CACHE_PATH
+
+
+def _parse_decimal(raw: str) -> Decimal:
+    return Decimal(str(raw))
+
+
+def _read_cache(path: Path) -> dict[date, SolDailyPrice]:
+    if not path.exists():
+        return {}
+    rows: dict[date, SolDailyPrice] = {}
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            day = date.fromisoformat(str(row["date"]))
+            rows[day] = SolDailyPrice(
+                day=day,
+                open=_parse_decimal(str(row["open"])),
+                high=_parse_decimal(str(row["high"])),
+                low=_parse_decimal(str(row["low"])),
+                close=_parse_decimal(str(row["close"])),
+                volume=_parse_decimal(str(row["volume"])),
+                source=str(row.get("source") or SOURCE),
+            )
+    return rows
+
+
+def _write_cache(path: Path, rows: Iterable[SolDailyPrice]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["date", "open", "high", "low", "close", "volume", "source"])
+        writer.writeheader()
+        for row in sorted(rows, key=lambda r: r.day):
+            writer.writerow(
+                {
+                    "date": row.day.isoformat(),
+                    "open": str(row.open),
+                    "high": str(row.high),
+                    "low": str(row.low),
+                    "close": str(row.close),
+                    "volume": str(row.volume),
+                    "source": row.source,
+                }
+            )
+    tmp.replace(path)
+
+
+def _missing_dates(cache: dict[date, SolDailyPrice], start_date: date, end_date: date) -> list[date]:
+    missing: list[date] = []
+    day = start_date
+    while day <= end_date:
+        if day not in cache:
+            missing.append(day)
+        day += timedelta(days=1)
+    return missing
+
+
+async def _download_range(start_date: date, end_date: date) -> dict[date, SolDailyPrice]:
+    period1 = int(datetime(start_date.year, start_date.month, start_date.day, tzinfo=timezone.utc).timestamp())
+    period2 = int(datetime(end_date.year, end_date.month, end_date.day, 23, 59, 59, tzinfo=timezone.utc).timestamp())
+    params = {"period1": period1, "period2": period2, "interval": "1d", "events": "history", "includeAdjustedClose": "true"}
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        resp = await client.get(YAHOO_DOWNLOAD_URL, params=params)
+        resp.raise_for_status()
+    parsed: dict[date, SolDailyPrice] = {}
+    reader = csv.DictReader(resp.text.splitlines())
+    for row in reader:
+        if not row.get("Date") or row.get("Close") in {None, "null", ""}:
+            continue
+        if row["Open"] == "null" or row["High"] == "null" or row["Low"] == "null" or row["Volume"] == "null":
+            continue
+        day = date.fromisoformat(row["Date"])
+        parsed[day] = SolDailyPrice(
+            day=day,
+            open=_parse_decimal(row["Open"]),
+            high=_parse_decimal(row["High"]),
+            low=_parse_decimal(row["Low"]),
+            close=_parse_decimal(row["Close"]),
+            volume=_parse_decimal(row["Volume"]),
+            source=SOURCE,
+        )
+    return parsed
+
+
+async def ensure_sol_usd_daily_prices(start_date: date, end_date: date) -> Path:
+    path = _cache_path()
+    cache = _read_cache(path)
+    missing = _missing_dates(cache, start_date, end_date)
+    if not missing:
+        return path
+    try:
+        downloaded = await _download_range(min(missing), max(missing))
+    except Exception as exc:
+        missing_after = _missing_dates(cache, start_date, end_date)
+        if not missing_after:
+            return path
+        raise RuntimeError(
+            f"SOL/USD price table unavailable; missing dates {missing_after[0].isoformat()}..{missing_after[-1].isoformat()}"
+        ) from exc
+    for day, row in downloaded.items():
+        cache[day] = row
+    missing_after = _missing_dates(cache, start_date, end_date)
+    if missing_after:
+        raise RuntimeError(
+            f"SOL/USD price table incomplete; missing dates {missing_after[0].isoformat()}..{missing_after[-1].isoformat()}"
+        )
+    _write_cache(path, cache.values())
+    return path
+
+
+def get_sol_usd_close_for_date(day: date) -> Decimal | None:
+    cache = _read_cache(_cache_path())
+    row = cache.get(day)
+    if row is None:
+        return None
+    return row.close
+
+
+def cache_stats(path: Path) -> tuple[int, date | None, date | None]:
+    cache = _read_cache(path)
+    if not cache:
+        return 0, None, None
+    days = sorted(cache)
+    return len(days), days[0], days[-1]

--- a/sol_cgt/tests/test_compute_fetch.py
+++ b/sol_cgt/tests/test_compute_fetch.py
@@ -29,6 +29,13 @@ def test_compute_fetches_missing_cache_with_fy_filters(monkeypatch) -> None:
 
     monkeypatch.setattr(cli, "AudPriceProvider", DummyPriceProvider)
 
+    async def fake_ensure(*args, **kwargs):
+        from pathlib import Path
+        return Path(".sol_cgt_cache/prices/sol_usd_daily.csv")
+
+    monkeypatch.setattr(cli.sol_price_table, "ensure_sol_usd_daily_prices", fake_ensure)
+    monkeypatch.setattr(cli.sol_price_table, "cache_stats", lambda *_: (0, None, None))
+
     cli.compute(
         wallet=["wallet"],
         config=None,

--- a/sol_cgt/tests/test_pricing.py
+++ b/sol_cgt/tests/test_pricing.py
@@ -6,14 +6,14 @@ from decimal import Decimal
 from sol_cgt import pricing
 
 
-def test_sol_price_via_kraken(monkeypatch) -> None:
-    async def fake_sol_price(*args, **kwargs):
+def test_sol_price_via_local_table(monkeypatch) -> None:
+    def fake_sol_price(*args, **kwargs):
         return Decimal("20")
 
     async def fake_fx(day):
         return Decimal("1.5")
 
-    monkeypatch.setattr(pricing.kraken, "get_sol_usd_close_for_date", fake_sol_price)
+    monkeypatch.setattr(pricing.sol_price_table, "get_sol_usd_close_for_date", fake_sol_price)
     monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
 
     provider = pricing.AudPriceProvider(api_key="key")
@@ -58,11 +58,8 @@ def test_sol_price_missing_warns(monkeypatch, caplog) -> None:
     async def fake_fx(day):
         return Decimal("1")
 
-    async def fake_kraken(*args, **kwargs):
-        raise RuntimeError("unavailable")
-
     monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
-    monkeypatch.setattr(pricing.kraken, "get_sol_usd_close_for_date", fake_kraken)
+    monkeypatch.setattr(pricing.sol_price_table, "get_sol_usd_close_for_date", lambda *_: None)
 
     provider = pricing.AudPriceProvider(api_key="key")
     ts = datetime(2024, 2, 1, tzinfo=timezone.utc)

--- a/sol_cgt/tests/test_sol_price_table.py
+++ b/sol_cgt/tests/test_sol_price_table.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sol_cgt.pricing import TimestampPriceProvider, WSOL_MINT, normalize_mint
+from sol_cgt.providers import sol_price_table
+
+
+def test_sol_mint_normalization_variants() -> None:
+    assert normalize_mint("SOL") == WSOL_MINT
+    assert normalize_mint("WSOL") == WSOL_MINT
+    assert normalize_mint(WSOL_MINT) == WSOL_MINT
+
+
+def test_ensure_prices_uses_cache_when_range_already_covered(tmp_path, monkeypatch) -> None:
+    cache_path = tmp_path / "prices.csv"
+    monkeypatch.setattr(sol_price_table, "CACHE_PATH", cache_path)
+    sol_price_table._write_cache(
+        cache_path,
+        [
+            sol_price_table.SolDailyPrice(date(2024, 1, 1), Decimal("10"), Decimal("11"), Decimal("9"), Decimal("10.5"), Decimal("100")),
+            sol_price_table.SolDailyPrice(date(2024, 1, 2), Decimal("10"), Decimal("11"), Decimal("9"), Decimal("10.5"), Decimal("100")),
+        ],
+    )
+
+    async def fail_download(*args, **kwargs):
+        raise AssertionError("download should not be called")
+
+    monkeypatch.setattr(sol_price_table, "_download_range", fail_download)
+    path = __import__("asyncio").run(sol_price_table.ensure_sol_usd_daily_prices(date(2024, 1, 1), date(2024, 1, 2)))
+    assert path == cache_path
+
+
+def test_missing_dates_detected(tmp_path, monkeypatch) -> None:
+    cache_path = tmp_path / "prices.csv"
+    monkeypatch.setattr(sol_price_table, "CACHE_PATH", cache_path)
+    sol_price_table._write_cache(
+        cache_path,
+        [sol_price_table.SolDailyPrice(date(2024, 1, 1), Decimal("1"), Decimal("1"), Decimal("1"), Decimal("1"), Decimal("1"))],
+    )
+
+    async def empty_download(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(sol_price_table, "_download_range", empty_download)
+    try:
+        __import__("asyncio").run(sol_price_table.ensure_sol_usd_daily_prices(date(2024, 1, 1), date(2024, 1, 3)))
+        assert False, "expected runtime error"
+    except RuntimeError as exc:
+        assert "missing dates" in str(exc)
+
+
+def test_sol_price_uses_au_local_date(monkeypatch) -> None:
+    provider = TimestampPriceProvider(api_key="key")
+    captured = {}
+
+    def fake(day):
+        captured["day"] = day
+        return Decimal("123")
+
+    monkeypatch.setattr(sol_price_table, "get_sol_usd_close_for_date", fake)
+    ts = datetime(2024, 1, 1, 13, 30, tzinfo=timezone.utc)
+    assert provider.price_usd("SOL", ts) == Decimal("123")
+    assert captured["day"].isoformat() == "2024-01-02"
+
+
+def test_non_sol_does_not_fallback_to_sol(monkeypatch) -> None:
+    provider = TimestampPriceProvider(api_key=None)
+    monkeypatch.setattr(sol_price_table, "get_sol_usd_close_for_date", lambda _day: Decimal("99"))
+    ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert provider.price_usd("TOKENX", ts) is None

--- a/sol_cgt/tests/test_valuation.py
+++ b/sol_cgt/tests/test_valuation.py
@@ -83,5 +83,5 @@ def test_provider_401_does_not_crash(monkeypatch, caplog) -> None:
     provider = TimestampPriceProvider(api_key="key")
     ts = datetime(2024, 8, 1, tzinfo=timezone.utc)
     with caplog.at_level("WARNING"):
-        assert provider.price_usd("SOL", ts) is None
+        assert provider.price_usd("TOKENX", ts) is None
     assert any("lookup failed" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
### Motivation
- Remove per-event Birdeye API calls for SOL pricing and replace them with a reproducible local daily SOL/USD price table to improve performance and remove a default external API key requirement. 
- Ensure SOL/WSOL/wrapped-SOL are normalized and always priced from a local daily close table using AU-local dates to produce deterministic, auditable valuations.

### Description
- Add `sol_cgt/providers/sol_price_table.py` which downloads `SOL-USD` daily history from Yahoo, parses Decimal-safe OHLCV rows, and caches them atomically at `.sol_cgt_cache/prices/sol_usd_daily.csv`, exposing `ensure_sol_usd_daily_prices(start_date, end_date)` and `get_sol_usd_close_for_date(day)`.
- Route SOL lookups in `sol_cgt/pricing/__init__.py` so `TimestampPriceProvider.price_usd` maps `SOL`/`WSOL`/wrapped-mint to the single WSOL mint and reads the AU-local date’s `close` price from the local table instead of calling Birdeye.
- Add CLI warmup in `sol_cgt/cli.py` so `compute` determines the required date range (FY bounds or event dates), calls `ensure_sol_usd_daily_prices(...)`, logs `SOL/USD daily price table ready path=... start=... end=... rows=... source=yahoo`, and made Birdeye optional via `--use-birdeye/--no-use-birdeye` (default off) so Birdeye is not required for normal runs.
- Update mint normalization to accept `"SOL"`, `"WSOL"`, and the wrapped SOL mint constant and add focused tests and minor test adjustments under `sol_cgt/tests/` for SOL pricing, cache coverage, AU-local date mapping, and CLI warmup integration.

### Testing
- Ran the full test suite with `pytest -q`; this failed in this environment due to network/proxy errors and missing async-test plugin (`pytest-asyncio`) and is unrelated to the functional changes made here. 
- Ran focused tests with `pytest -q sol_cgt/tests/test_pricing.py sol_cgt/tests/test_valuation.py sol_cgt/tests/test_sol_price_table.py sol_cgt/tests/test_compute_fetch.py` and they passed. 
- Ran `ruff check sol_cgt` which reported pre-existing lint issues in unrelated modules; I fixed a minor unused-import in the new provider file before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7becc1f48331828139374a35bd55)