### PR TITLE
Add bulk USD/AUD FX table caching and combined raw tx export

### DIFF
--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -31,7 +31,7 @@ from .types import MissingLotIssue, NormalizedEvent
 from . import utils
 from .utils import australian_financial_year_bounds, parse_local_date
 from .providers import jupiter as jupiter_provider
-from .providers import sol_price_table
+from .providers import fx_price_table, sol_price_table
 
 _orig_option_init = typer.core.TyperOption.__init__
 logger = logging.getLogger(__name__)
@@ -244,16 +244,17 @@ def _json_default(value):
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
-def _export_raw_transactions(xlsx_path: Path, wallet: str, fy_label: Optional[str], source: str, raw_items: list[dict]) -> Path:
+def _export_raw_transactions(xlsx_path: Path, wallets: list[str], fy_label: Optional[str], source: str, raw_by_wallet: dict[str, list[dict]]) -> Path:
     output_dir = xlsx_path.parent
     output_dir.mkdir(parents=True, exist_ok=True)
+    total_count = sum(len(items) for items in raw_by_wallet.values())
     payload = {
-        "wallet": wallet,
+        "wallets": wallets,
         "fy": fy_label or "all",
-        "raw_txs_count": len(raw_items),
+        "raw_txs_count": total_count,
         "exported_at": datetime.now(timezone.utc).isoformat(),
         "source": source,
-        "transactions": raw_items,
+        "transactions_by_wallet": raw_by_wallet,
     }
     export_path = output_dir / "raw_transactions.json"
     pretty_path = output_dir / "raw_transactions.pretty.json"
@@ -426,12 +427,13 @@ def compute(
                 continue
         raw_items = fetch_mod.load_cached(addr)
         raw_by_wallet[addr] = raw_items
-        if xlsx_path:
-            try:
-                export_path = _export_raw_transactions(xlsx_path, addr, fy_label, "helius-cache", raw_items)
-            except Exception as exc:
-                raise RuntimeError(f"Failed to export raw transactions for wallet={addr} path={xlsx_path.parent}: {exc}") from exc
-            logger.info("Raw transactions exported path=%s count=%s", export_path, len(raw_items))
+
+    if xlsx_path and raw_by_wallet:
+        try:
+            export_path = _export_raw_transactions(xlsx_path, wallets, fy_label, "helius-cache", raw_by_wallet)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to export raw transactions path={xlsx_path.parent}: {exc}") from exc
+        logger.info("Raw transactions exported path=%s wallets=%s count=%s", export_path, len(raw_by_wallet), sum(len(v) for v in raw_by_wallet.values()))
 
     events, kind_counts = _load_and_normalize(
         wallets,
@@ -450,6 +452,9 @@ def compute(
         cache_path = asyncio.run(sol_price_table.ensure_sol_usd_daily_prices(start_day, end_day))
         rows, _, _ = sol_price_table.cache_stats(cache_path)
         logger.info("SOL/USD daily price table ready path=%s start=%s end=%s rows=%s source=kraken", cache_path, start_day.isoformat(), end_day.isoformat(), rows)
+        fx_cache_path = asyncio.run(fx_price_table.ensure_usd_aud_daily_rates(start_day, end_day))
+        fx_rows, _, _ = fx_price_table.cache_stats(fx_cache_path)
+        logger.info("USD/AUD daily FX table ready path=%s start=%s end=%s rows=%s source=frankfurter", fx_cache_path, start_day.isoformat(), end_day.isoformat(), fx_rows)
     usd_provider = TimestampPriceProvider()
     price_provider = AudPriceProvider(
         fx_source=settings.fx_source,

--- a/sol_cgt/pricing/__init__.py
+++ b/sol_cgt/pricing/__init__.py
@@ -1,9 +1,7 @@
 """AUD price provider with timestamp-aware pricing."""
 from __future__ import annotations
 
-import asyncio
 import logging
-import threading
 from datetime import datetime
 from decimal import Decimal
 from functools import lru_cache
@@ -11,7 +9,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from .. import utils
-from ..providers import fx_rates, rba_fx, sol_price_table
+from ..providers import fx_price_table, sol_price_table
 
 WSOL_MINT = "So11111111111111111111111111111111111111112"
 USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
@@ -144,36 +142,7 @@ class AudPriceProvider:
 
     def fx_rate(self, ts: datetime) -> Decimal:
         fx_day = utils.to_au_local(ts).date()
-        try:
-            if self.fx_source == "rba":
-                return rba_fx.usd_to_aud_rate(fx_day)
-            return _run_async(fx_rates.usd_to_aud_rate(fx_day))
-        except Exception:
-            return rba_fx.usd_to_aud_rate(fx_day)
-
-
-def _run_async(coro):
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    result_container: dict[str, Decimal] = {}
-    error_container: dict[str, BaseException] = {}
-
-    def runner() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            result_container["result"] = loop.run_until_complete(coro)
-        except BaseException as exc:  # pragma: no cover - defensive
-            error_container["error"] = exc
-        finally:
-            loop.close()
-
-    thread = threading.Thread(target=runner)
-    thread.start()
-    thread.join()
-    if "error" in error_container:
-        raise error_container["error"]
-    return result_container["result"]
+        rate = fx_price_table.get_usd_aud_for_date_or_prior(fx_day)
+        if rate is None:
+            raise RuntimeError(f"USD/AUD FX rate unavailable in local cache for {fx_day.isoformat()}")
+        return rate

--- a/sol_cgt/providers/fx_price_table.py
+++ b/sol_cgt/providers/fx_price_table.py
@@ -1,0 +1,132 @@
+"""USD/AUD daily FX table provider with local CSV cache."""
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+
+CACHE_PATH = Path(".sol_cgt_cache") / "fx" / "usd_aud_daily.csv"
+BASE_URL = "https://api.frankfurter.dev"
+SOURCE = "frankfurter"
+
+
+@dataclass(frozen=True)
+class FxDailyRate:
+    day: date
+    usd_to_aud: Decimal
+    source: str = SOURCE
+
+
+def _parse_decimal(raw: str) -> Decimal:
+    return Decimal(str(raw))
+
+
+def _read_cache(path: Path) -> dict[date, FxDailyRate]:
+    if not path.exists():
+        return {}
+    rows: dict[date, FxDailyRate] = {}
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        for row in csv.DictReader(fh):
+            day = date.fromisoformat(str(row["date"]))
+            rows[day] = FxDailyRate(day=day, usd_to_aud=_parse_decimal(str(row["usd_to_aud"])), source=str(row.get("source") or SOURCE))
+    return rows
+
+
+def _write_cache(path: Path, rows: Iterable[FxDailyRate]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["date", "usd_to_aud", "source"])
+        writer.writeheader()
+        for row in sorted(rows, key=lambda r: r.day):
+            writer.writerow({"date": row.day.isoformat(), "usd_to_aud": str(row.usd_to_aud), "source": row.source})
+    tmp.replace(path)
+
+
+def _missing_dates(cache: dict[date, FxDailyRate], start_date: date, end_date: date) -> list[date]:
+    out: list[date] = []
+    day = start_date
+    while day <= end_date:
+        if day not in cache:
+            out.append(day)
+        day += timedelta(days=1)
+    return out
+
+
+def _collapse_ranges(days: list[date]) -> list[tuple[date, date]]:
+    if not days:
+        return []
+    days = sorted(days)
+    ranges: list[tuple[date, date]] = []
+    start = end = days[0]
+    for day in days[1:]:
+        if day == end + timedelta(days=1):
+            end = day
+        else:
+            ranges.append((start, end))
+            start = end = day
+    ranges.append((start, end))
+    return ranges
+
+
+async def _download_range(start_date: date, end_date: date) -> dict[date, FxDailyRate]:
+    params = {"from": start_date.isoformat(), "to": end_date.isoformat(), "base": "USD", "quotes": "AUD"}
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        resp = await client.get(f"{BASE_URL}/v2/rates", params=params)
+        resp.raise_for_status()
+        payload = resp.json()
+    rates = payload.get("rates") if isinstance(payload, dict) else None
+    if not isinstance(rates, dict):
+        raise RuntimeError("Missing rates from Frankfurter response")
+    parsed: dict[date, FxDailyRate] = {}
+    for day_raw, quote_map in rates.items():
+        if not isinstance(quote_map, dict) or "AUD" not in quote_map:
+            continue
+        day = date.fromisoformat(day_raw)
+        if day < start_date or day > end_date:
+            continue
+        parsed[day] = FxDailyRate(day=day, usd_to_aud=_parse_decimal(str(quote_map["AUD"])), source=SOURCE)
+    return parsed
+
+
+async def ensure_usd_aud_daily_rates(start_date: date, end_date: date) -> Path:
+    path = CACHE_PATH
+    cache = _read_cache(path)
+    missing = _missing_dates(cache, start_date, end_date)
+    if not missing:
+        return path
+    for range_start, range_end in _collapse_ranges(missing):
+        cache.update(await _download_range(range_start, range_end))
+    still_missing = _missing_dates(cache, start_date, end_date)
+    if still_missing:
+        raise RuntimeError(f"USD/AUD FX table incomplete requested={start_date}..{end_date} missing={still_missing[0]}..{still_missing[-1]}")
+    _write_cache(path, cache.values())
+    return path
+
+
+def get_usd_aud_for_date(day: date) -> Decimal | None:
+    row = _read_cache(CACHE_PATH).get(day)
+    return row.usd_to_aud if row else None
+
+
+def get_usd_aud_for_date_or_prior(day: date) -> Decimal | None:
+    cache = _read_cache(CACHE_PATH)
+    if day in cache:
+        return cache[day].usd_to_aud
+    prior = [d for d in cache if d <= day]
+    if not prior:
+        return None
+    return cache[max(prior)].usd_to_aud
+
+
+def cache_stats(path: Path) -> tuple[int, date | None, date | None]:
+    cache = _read_cache(path)
+    if not cache:
+        return 0, None, None
+    days = sorted(cache)
+    return len(days), days[0], days[-1]

--- a/sol_cgt/tests/test_fx_price_table.py
+++ b/sol_cgt/tests/test_fx_price_table.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sol_cgt import pricing
+from sol_cgt.providers import fx_price_table
+
+
+def test_missing_ranges_collapsed() -> None:
+    ranges = fx_price_table._collapse_ranges([date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 4)])
+    assert ranges == [(date(2024, 1, 1), date(2024, 1, 2)), (date(2024, 1, 4), date(2024, 1, 4))]
+
+
+def test_ensure_rates_uses_cache_when_range_already_covered(tmp_path, monkeypatch) -> None:
+    cache_path = tmp_path / "fx.csv"
+    monkeypatch.setattr(fx_price_table, "CACHE_PATH", cache_path)
+    fx_price_table._write_cache(cache_path, [fx_price_table.FxDailyRate(date(2024, 1, 1), Decimal("1.5")), fx_price_table.FxDailyRate(date(2024, 1, 2), Decimal("1.6"))])
+
+    async def fail_download(*args, **kwargs):
+        raise AssertionError("download should not be called")
+
+    monkeypatch.setattr(fx_price_table, "_download_range", fail_download)
+    path = __import__("asyncio").run(fx_price_table.ensure_usd_aud_daily_rates(date(2024, 1, 1), date(2024, 1, 2)))
+    assert path == cache_path
+
+
+def test_fx_rate_uses_au_local_date_and_prior_fallback(monkeypatch) -> None:
+    captured = {}
+
+    def fake(day):
+        captured["day"] = day
+        if day.isoformat() == "2024-01-02":
+            return Decimal("1.55")
+        return None
+
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", fake)
+    provider = pricing.AudPriceProvider()
+    ts = datetime(2024, 1, 1, 13, 30, tzinfo=timezone.utc)
+    assert provider.fx_rate(ts) == Decimal("1.55")
+    assert captured["day"].isoformat() == "2024-01-02"
+
+
+def test_fx_rate_no_network_calls(monkeypatch) -> None:
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", lambda _day: Decimal("1.5"))
+    provider = pricing.AudPriceProvider()
+    ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert provider.fx_rate(ts) == Decimal("1.5")

--- a/sol_cgt/tests/test_pricing.py
+++ b/sol_cgt/tests/test_pricing.py
@@ -10,11 +10,8 @@ def test_sol_price_via_local_table(monkeypatch) -> None:
     def fake_sol_price(*args, **kwargs):
         return Decimal("20")
 
-    async def fake_fx(day):
-        return Decimal("1.5")
-
     monkeypatch.setattr(pricing.sol_price_table, "get_sol_usd_close_for_date", fake_sol_price)
-    monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", lambda _day: Decimal("1.5"))
 
     provider = pricing.AudPriceProvider(api_key="key")
     ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -22,10 +19,7 @@ def test_sol_price_via_local_table(monkeypatch) -> None:
 
 
 def test_stablecoin_conversion(monkeypatch) -> None:
-    async def fake_fx(day):
-        return Decimal("1.5")
-
-    monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", lambda _day: Decimal("1.5"))
 
     provider = pricing.AudPriceProvider()
     ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -33,10 +27,7 @@ def test_stablecoin_conversion(monkeypatch) -> None:
 
 
 def test_non_sol_token_unpriced(monkeypatch, tmp_path) -> None:
-    async def fake_fx(day):
-        return Decimal("1.0")
-
-    monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", lambda _day: Decimal("1.0"))
 
     cache = pricing.PriceCache(tmp_path)
     usd_provider = pricing.TimestampPriceProvider(api_key="key", cache=cache)
@@ -46,10 +37,7 @@ def test_non_sol_token_unpriced(monkeypatch, tmp_path) -> None:
 
 
 def test_sol_price_missing_warns(monkeypatch, caplog) -> None:
-    async def fake_fx(day):
-        return Decimal("1")
-
-    monkeypatch.setattr(pricing.fx_rates, "usd_to_aud_rate", fake_fx)
+    monkeypatch.setattr(pricing.fx_price_table, "get_usd_aud_for_date_or_prior", lambda _day: Decimal("1"))
     monkeypatch.setattr(pricing.sol_price_table, "get_sol_usd_close_for_date", lambda *_: None)
 
     provider = pricing.AudPriceProvider(api_key="key")

--- a/sol_cgt/tests/test_raw_export.py
+++ b/sol_cgt/tests/test_raw_export.py
@@ -6,16 +6,18 @@ from sol_cgt import cli
 from sol_cgt.config import APIKeys, AppSettings
 
 
-def test_compute_writes_raw_transactions_before_price_warmup(monkeypatch, tmp_path: Path) -> None:
-    settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
+def test_compute_writes_combined_raw_transactions_before_price_warmup(monkeypatch, tmp_path: Path) -> None:
+    settings = AppSettings(wallets=["wallet1", "wallet2"], api_keys=APIKeys(helius="key"))
     monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
     monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: True)
-    monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda _: [{"signature": "abc", "blockTime": 1}])
+    monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda w: [{"signature": f"{w}-sig", "blockTime": 1}])
 
     order: list[str] = []
 
-    def fake_export(xlsx_path, wallet, fy_label, source, raw_items):
+    def fake_export(xlsx_path, wallets, fy_label, source, raw_by_wallet):
         order.append("export")
+        assert wallets == ["wallet1", "wallet2"]
+        assert set(raw_by_wallet) == {"wallet1", "wallet2"}
         p = xlsx_path.parent / "raw_transactions.json"
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text("{}", encoding="utf-8")
@@ -24,16 +26,22 @@ def test_compute_writes_raw_transactions_before_price_warmup(monkeypatch, tmp_pa
     async def fake_normalize(*args, **kwargs):
         return []
 
-    async def fake_ensure(*args, **kwargs):
-        order.append("price")
+    async def fake_ensure_sol(*args, **kwargs):
+        order.append("sol")
         return Path(".sol_cgt_cache/prices/sol_usd_daily.csv")
+
+    async def fake_ensure_fx(*args, **kwargs):
+        order.append("fx")
+        return Path(".sol_cgt_cache/fx/usd_aud_daily.csv")
 
     monkeypatch.setattr(cli, "_export_raw_transactions", fake_export)
     monkeypatch.setattr(cli, "_normalize_wallet", fake_normalize)
-    monkeypatch.setattr(cli.sol_price_table, "ensure_sol_usd_daily_prices", fake_ensure)
+    monkeypatch.setattr(cli.sol_price_table, "ensure_sol_usd_daily_prices", fake_ensure_sol)
     monkeypatch.setattr(cli.sol_price_table, "cache_stats", lambda *_: (0, None, None))
+    monkeypatch.setattr(cli.fx_price_table, "ensure_usd_aud_daily_rates", fake_ensure_fx)
+    monkeypatch.setattr(cli.fx_price_table, "cache_stats", lambda *_: (0, None, None))
 
-    cli.compute(wallet=["wallet"], config=None, outdir=None, method=None, fy="2024-2025", fy_start=None, fy_end=None, fmt="csv", xlsx_path=tmp_path / "reports" / "out.xlsx", sol_price_csv=None, dry_run=True, fetch=False)
+    cli.compute(wallet=["wallet1", "wallet2"], config=None, outdir=None, method=None, fy="2024-2025", fy_start=None, fy_end=None, fmt="csv", xlsx_path=tmp_path / "reports" / "out.xlsx", sol_price_csv=None, dry_run=True, fetch=False)
 
-    assert order[0] == "export"
+    assert order[:1] == ["export"]
     assert (tmp_path / "reports" / "raw_transactions.json").exists()


### PR DESCRIPTION
### Motivation
- Prevent per-event USD→AUD HTTP lookups (which hit redirects and retried Frankfurter calls) by using a local daily FX table for valuation.  
- Avoid implicit per-event fallback into the broken RBA CSV parser during valuation by requiring a local FX cache lookup.  
- Fix multi-wallet raw transaction export which previously overwrote files by writing one combined export once before normalization/pricing.

### Description
- Added a new provider `sol_cgt/providers/fx_price_table.py` implementing a local CSV daily FX cache at `.sol_cgt_cache/fx/usd_aud_daily.csv` with `FxDailyRate` rows, `ensure_usd_aud_daily_rates(start,end)`, atomic `_write_cache`, `_missing_dates`, `_collapse_ranges`, and bulk range downloads against `https://api.frankfurter.dev/v2/rates` (uses `follow_redirects=True` in the client).  
- Changed AUD pricing to use the local table only by replacing runtime HTTP fallbacks: `AudPriceProvider.fx_rate(ts)` now converts to AU local date and reads `fx_price_table.get_usd_aud_for_date_or_prior(day)` and raises if missing, removing per-event calls to Frankfurter/RBA.  
- Updated compute flow and raw export in `sol_cgt/cli.py` to: load raw txs for all wallets, write one combined `raw_transactions.json` / `raw_transactions.pretty.json` payload (shape: `wallets`, `fy`, `raw_txs_count`, `transactions_by_wallet`), then normalize, then warm SOL/USD table, then warm USD/AUD FX table with logging, before calling valuation.  
- Added tests and adjustments: `sol_cgt/tests/test_fx_price_table.py` (cache behaviour, range collapsing, AU-local date + prior-day fallback), updated `sol_cgt/tests/test_raw_export.py` (combined-export ordering), and updated `sol_cgt/tests/test_pricing.py` to exercise the new local FX lookup.

### Testing
- Ran unit tests: `pytest -q sol_cgt/tests/test_fx_price_table.py sol_cgt/tests/test_raw_export.py sol_cgt/tests/test_sol_price_table.py sol_cgt/tests/test_pricing.py`, and they passed.  
- Verified logs are emitted when warming caches (e.g. `"SOL/USD daily price table ready path=..."` and `"USD/AUD daily FX table ready path=... start=... end=... rows=... source=frankfurter"`).  
- Attempted the full compute run from the instructions (`solcgt compute --wallet ... --fy "2024-2025" --format both --xlsx out.xlsx`) but this environment does not have `solcgt` on PATH so the command could not be executed here; the change is implemented so the compute flow warms the FX cache before valuation and will avoid per-event Frankfurter calls when run in a normal environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa85df598083319e71b1abd165af00)