### PR TITLE
Scope normalized events to FY end before valuation/accounting

### DIFF
--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -221,6 +221,13 @@ def _required_price_dates(events: list[NormalizedEvent], fy_period: Optional[uti
     return min(days), max(days)
 
 
+def _events_required_for_fy(events: list[NormalizedEvent], fy_period: Optional[utils.Period]) -> list[NormalizedEvent]:
+    if fy_period is None:
+        return events
+    fy_end = utils.to_au_local(fy_period.end).date()
+    return [event for event in events if utils.to_au_local(event.ts).date() <= fy_end]
+
+
 def _json_default(value):
     from dataclasses import asdict, is_dataclass
     from enum import Enum
@@ -446,7 +453,19 @@ def compute(
         force_fetch=False,
     )
     _apply_kind_breakdown(kind_counts)
-    price_dates = _required_price_dates(events, fy_period)
+    scoped_events = _events_required_for_fy(events, fy_period)
+    if fy_period is not None:
+        fy_end = utils.to_au_local(fy_period.end).date().isoformat()
+        dropped_post_fy = len(events) - len(scoped_events)
+        logger.info(
+            "FY event scope applied fy=%s original_events=%s scoped_events=%s dropped_post_fy=%s fy_end=%s",
+            fy_label,
+            len(events),
+            len(scoped_events),
+            dropped_post_fy,
+            fy_end,
+        )
+    price_dates = _required_price_dates(scoped_events, fy_period)
     if price_dates is not None:
         start_day, end_day = price_dates
         cache_path = asyncio.run(sol_price_table.ensure_sol_usd_daily_prices(start_day, end_day))
@@ -461,18 +480,18 @@ def compute(
         usd_provider=usd_provider,
     )
     if dry_run:
-        typer.echo(f"Loaded {len(events)} normalized events across {len(wallets)} wallet(s)")
+        typer.echo(f"Loaded {len(scoped_events)} normalized events across {len(wallets)} wallet(s)")
         return
     missing_lot_issues: list[MissingLotIssue] = []
     valuation_warnings = valuation_module.valuate_events(
-        events,
+        scoped_events,
         valuation_module.ValuationContext(
             usd_provider=usd_provider,
             fx_rate=price_provider.fx_rate,
         ),
     )
     result, stopped_for_missing = _run_accounting(
-        events=events,
+        events=scoped_events,
         wallets=wallets,
         settings=settings,
         price_provider=price_provider,
@@ -506,16 +525,28 @@ def compute(
                 force_fetch=True,
             )
             _apply_kind_breakdown(kind_counts)
+            scoped_events = _events_required_for_fy(events, fy_period)
+            if fy_period is not None:
+                fy_end = utils.to_au_local(fy_period.end).date().isoformat()
+                dropped_post_fy = len(events) - len(scoped_events)
+                logger.info(
+                    "FY event scope applied fy=%s original_events=%s scoped_events=%s dropped_post_fy=%s fy_end=%s",
+                    fy_label,
+                    len(events),
+                    len(scoped_events),
+                    dropped_post_fy,
+                    fy_end,
+                )
             missing_lot_issues.clear()
             valuation_warnings = valuation_module.valuate_events(
-                events,
+                scoped_events,
                 valuation_module.ValuationContext(
                     usd_provider=usd_provider,
                     fx_rate=price_provider.fx_rate,
                 ),
             )
             result, stopped_for_missing = _run_accounting(
-                events=events,
+                events=scoped_events,
                 wallets=wallets,
                 settings=settings,
                 price_provider=price_provider,
@@ -560,7 +591,7 @@ def compute(
         output_dir = output_dir / fy_label
     formats.export_reports(output_dir, acquisitions, disposals, summary_by_token, summary_overall, fmt=fmt)
     if xlsx_path:
-        for event in events:
+        for event in scoped_events:
             if event.fee_sol and "fee_aud" not in event.raw:
                 fee_price = price_provider.price_aud("SOL", event.ts, context=event.raw)
                 if fee_price is None:
@@ -588,7 +619,7 @@ def compute(
                 "Warnings": str(len(warnings)),
                 "Missing lots": str(len(missing_lot_issues)),
             },
-            events=[ev for ev in events if not fy_period or fy_period.start <= ev.ts <= fy_period.end],
+            events=[ev for ev in scoped_events if not fy_period or fy_period.start <= ev.ts <= fy_period.end],
             lots=acquisitions,
             disposals=disposals,
             summary_by_token=summary_by_token,

--- a/sol_cgt/tests/test_compute_fetch.py
+++ b/sol_cgt/tests/test_compute_fetch.py
@@ -35,6 +35,8 @@ def test_compute_fetches_missing_cache_with_fy_filters(monkeypatch) -> None:
 
     monkeypatch.setattr(cli.sol_price_table, "ensure_sol_usd_daily_prices", fake_ensure)
     monkeypatch.setattr(cli.sol_price_table, "cache_stats", lambda *_: (0, None, None))
+    monkeypatch.setattr(cli.fx_price_table, "ensure_usd_aud_daily_rates", fake_ensure)
+    monkeypatch.setattr(cli.fx_price_table, "cache_stats", lambda *_: (0, None, None))
 
     cli.compute(
         wallet=["wallet"],

--- a/sol_cgt/tests/test_fy_event_scope.py
+++ b/sol_cgt/tests/test_fy_event_scope.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sol_cgt import cli, utils
+from sol_cgt.accounting.engine import AccountingResult
+from sol_cgt.config import APIKeys, AppSettings
+from sol_cgt.types import DisposalRecord, NormalizedEvent
+
+
+def _event(event_id: str, ts: datetime) -> NormalizedEvent:
+    return NormalizedEvent(id=event_id, ts=ts, kind="unknown", wallet="w", fee_sol=Decimal("0"), raw={})
+
+
+def test_events_required_for_fy_keeps_prefy_and_fy_drops_post_fy() -> None:
+    fy_period = utils.australian_financial_year_bounds("2024-2025")
+    events = [
+        _event("pre", datetime(2024, 6, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("in", datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("post", datetime(2025, 7, 1, 0, 0, tzinfo=timezone.utc)),
+    ]
+
+    scoped = cli._events_required_for_fy(events, fy_period)
+    assert [event.id for event in scoped] == ["pre", "in"]
+
+
+def test_events_required_for_fy_uses_au_local_date_cutoff() -> None:
+    fy_period = utils.australian_financial_year_bounds("2024-2025")
+    # 2025-06-30 in AU local time (AEST) -> should be retained.
+    in_au_day = _event("in-au", datetime(2025, 6, 30, 13, 30, tzinfo=timezone.utc))
+    # 2025-07-01 in AU local time -> should be dropped.
+    post_au_day = _event("post-au", datetime(2025, 6, 30, 15, 0, tzinfo=timezone.utc))
+
+    scoped = cli._events_required_for_fy([in_au_day, post_au_day], fy_period)
+    assert [event.id for event in scoped] == ["in-au"]
+
+
+def test_required_price_dates_excludes_post_fy_events() -> None:
+    fy_period = utils.australian_financial_year_bounds("2024-2025")
+    events = [
+        _event("pre", datetime(2024, 6, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("in", datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc)),
+    ]
+    scoped = cli._events_required_for_fy(events, fy_period)
+    start_day, end_day = cli._required_price_dates(scoped, fy_period)
+    assert start_day.isoformat() == "2024-07-01"
+    assert end_day.isoformat() == "2025-06-30"
+
+
+def test_no_fy_keeps_all_events() -> None:
+    events = [
+        _event("a", datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("b", datetime(2025, 10, 11, 0, 0, tzinfo=timezone.utc)),
+    ]
+    assert cli._events_required_for_fy(events, None) == events
+
+
+def test_compute_values_only_scoped_events(monkeypatch) -> None:
+    settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
+    monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: True)
+    monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda _: [])
+
+    events = [
+        _event("pre", datetime(2024, 6, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("fy", datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc)),
+        _event("post", datetime(2025, 10, 11, 0, 0, tzinfo=timezone.utc)),
+    ]
+    monkeypatch.setattr(cli, "_load_and_normalize", lambda *args, **kwargs: (events, {"unknown": len(events)}))
+    async def fake_ensure_sol(*args, **kwargs):
+        return None
+
+    async def fake_ensure_fx(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(cli.sol_price_table, "ensure_sol_usd_daily_prices", fake_ensure_sol)
+    monkeypatch.setattr(cli.sol_price_table, "cache_stats", lambda *_: (0, None, None))
+    monkeypatch.setattr(cli.fx_price_table, "ensure_usd_aud_daily_rates", fake_ensure_fx)
+    monkeypatch.setattr(cli.fx_price_table, "cache_stats", lambda *_: (0, None, None))
+
+    class DummyPriceProvider:
+        def __init__(self, *args, **kwargs) -> None:
+            self.fx_dates: list[str] = []
+
+        def fx_rate(self, ts):
+            self.fx_dates.append(utils.to_au_local(ts).date().isoformat())
+            return Decimal("1")
+
+        def price_aud(self, *args, **kwargs):
+            return Decimal("1")
+
+    monkeypatch.setattr(cli, "AudPriceProvider", DummyPriceProvider)
+
+    captured_ids: list[str] = []
+
+    def fake_valuate_events(input_events, ctx):
+        for event in input_events:
+            captured_ids.append(event.id)
+            ctx.fx_rate(event.ts)
+        return []
+
+    monkeypatch.setattr(cli.valuation_module, "valuate_events", fake_valuate_events)
+
+    in_fy_disposal = DisposalRecord(
+        event_id="fy",
+        wallet="wallet",
+        ts=datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc),
+        token_mint="mint",
+        qty_disposed=Decimal("1"),
+        proceeds_aud=Decimal("1"),
+        cost_base_aud=Decimal("1"),
+        fees_aud=Decimal("0"),
+        gain_loss_aud=Decimal("0"),
+        long_term=False,
+        held_days=1,
+        method="FIFO",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_run_accounting",
+        lambda **kwargs: (AccountingResult(acquisitions=[], disposals=[in_fy_disposal], lot_moves=[], warnings=[]), False),
+    )
+    monkeypatch.setattr(cli.formats, "export_reports", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.console_report, "render_summary", lambda *args, **kwargs: None)
+
+    cli.compute(wallet=["wallet"], fy="2024-2025", fy_start=None, fy_end=None, dry_run=False, fetch=False, fmt="csv", config=None, outdir=None, method=None, xlsx_path=None, sol_price_csv=None)
+
+    assert captured_ids == ["pre", "fy"]


### PR DESCRIPTION
### Motivation
- Prevent valuation and FX lookups for events after the requested Australian financial year end when `--fy` is supplied, while still retaining pre-FY history for lot reconstruction.

### Description
- Add helper ` _events_required_for_fy(events, fy_period)` which keeps events whose `to_au_local(event.ts).date() <= fy_end` and returns all events when no FY is supplied.
- Apply the FY cutoff immediately after normalization and before price-range computation so `_required_price_dates(...)`, SOL/USD warmup and USD/AUD warmup are computed from the scoped events.
- Pass the scoped events into `valuation_module.valuate_events(...)` and `_run_accounting(...)` and ensure XLSX event export uses the scoped event list, while leaving raw transaction export unchanged.
- Add an info log line: `FY event scope applied fy=... original_events=... scoped_events=... dropped_post_fy=... fy_end=...` and apply the same scoping during auto-backfill reloads.

### Testing
- Added unit tests in `sol_cgt/tests/test_fy_event_scope.py` covering pre-FY retention, AU local-date cutoff behavior, price date range exclusion of post-FY dates, no-FY pass-through, and that `compute` valuates only scoped events.
- Updated `sol_cgt/tests/test_compute_fetch.py` stubs to ensure FX warmup is mocked during FY tests.
- Ran `pytest -q sol_cgt/tests/test_fy_event_scope.py sol_cgt/tests/test_raw_export.py sol_cgt/tests/test_compute_fetch.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa88f67c6c8331b408de3d4f1a2510)