### PR TITLE
Classify multi-wallet internal transfers and exclude them from taxable accounting

### DIFF
--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -92,6 +92,10 @@ class AccountingEngine:
         missing_price_warned: set[tuple[str, str, str]] = set()
 
         for event in sorted(events, key=lambda ev: (ev.ts, ev.id)):
+            if event.raw.get("is_internal_transfer_duplicate"):
+                continue
+            if event.kind == "transfer_internal":
+                continue
             if event.id in matched_in_ids:
                 continue
             if event.id in match_by_out:

--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -192,8 +192,14 @@ def _run_accounting(
 
 def _collect_wallets(wallet_values: Optional[List[str]]) -> List[str]:
     wallets: List[str] = []
+    seen: set[str] = set()
     for entry in wallet_values or []:
-        wallets.extend([w.strip() for w in entry.split(",") if w.strip()])
+        for wallet in [w.strip() for w in entry.split(",") if w.strip()]:
+            normalized = transfers.normalize_wallet_address(wallet)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            wallets.append(normalized)
     return wallets
 
 
@@ -453,6 +459,8 @@ def compute(
         force_fetch=False,
     )
     _apply_kind_breakdown(kind_counts)
+    transfer_stats = transfers.classify_internal_transfers(events, wallets)
+    logger.info("Internal transfer classification complete owned_wallets=%s internal_transfers=%s external_transfer_in=%s external_transfer_out=%s", transfer_stats["owned_wallets"], transfer_stats["internal_transfers"], transfer_stats["external_transfer_in"], transfer_stats["external_transfer_out"])
     scoped_events = _events_required_for_fy(events, fy_period)
     if fy_period is not None:
         fy_end = utils.to_au_local(fy_period.end).date().isoformat()
@@ -525,6 +533,8 @@ def compute(
                 force_fetch=True,
             )
             _apply_kind_breakdown(kind_counts)
+            transfer_stats = transfers.classify_internal_transfers(events, wallets)
+            logger.info("Internal transfer classification complete owned_wallets=%s internal_transfers=%s external_transfer_in=%s external_transfer_out=%s", transfer_stats["owned_wallets"], transfer_stats["internal_transfers"], transfer_stats["external_transfer_in"], transfer_stats["external_transfer_out"])
             scoped_events = _events_required_for_fy(events, fy_period)
             if fy_period is not None:
                 fy_end = utils.to_au_local(fy_period.end).date().isoformat()

--- a/sol_cgt/reconciliation/transfers.py
+++ b/sol_cgt/reconciliation/transfers.py
@@ -9,6 +9,67 @@ from typing import Deque, Dict, Iterable, List, Optional, Tuple
 from ..types import NormalizedEvent
 
 
+def normalize_wallet_address(value: Optional[str]) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def classify_internal_transfers(
+    events: Iterable[NormalizedEvent], wallets: Iterable[str]
+) -> dict[str, int]:
+    wallet_set = {w for w in (normalize_wallet_address(wallet) for wallet in wallets) if w}
+    internal_keys: set[tuple[str, str, str, str, str, str]] = set()
+    internal_count = 0
+    external_in = 0
+    external_out = 0
+    for event in events:
+        if event.kind not in {"transfer_in", "transfer_out"}:
+            continue
+        from_wallet = normalize_wallet_address(
+            event.raw.get("transfer_from_wallet") or event.raw.get("source_wallet")
+        )
+        to_wallet = normalize_wallet_address(
+            event.raw.get("transfer_to_wallet") or event.raw.get("destination_wallet")
+        )
+        mint = (event.base_token.mint if event.base_token else (event.quote_token.mint if event.quote_token else ""))
+        amount = str(event.base_token.amount if event.base_token else (event.quote_token.amount if event.quote_token else Decimal("0")))
+        signature = str(event.raw.get("signature") or event.id.split("#")[0])
+        dedupe_key = (signature, mint, amount, from_wallet or "", to_wallet or "", event.ts.isoformat())
+        is_internal = bool(from_wallet and to_wallet and from_wallet in wallet_set and to_wallet in wallet_set)
+        if is_internal:
+            event.kind = "transfer_internal"
+            event.tags.add("self_transfer")
+            event.raw.update(
+                {
+                    "is_internal_transfer": True,
+                    "internal_transfer_reason": "both endpoints are provided wallets",
+                    "from_wallet": from_wallet,
+                    "to_wallet": to_wallet,
+                    "asset_mint": mint,
+                    "amount": amount,
+                }
+            )
+            if dedupe_key in internal_keys:
+                event.tags.add("internal_transfer_duplicate")
+                event.raw["is_internal_transfer_duplicate"] = True
+            else:
+                internal_keys.add(dedupe_key)
+                internal_count += 1
+            continue
+        if event.kind == "transfer_in":
+            external_in += 1
+        else:
+            external_out += 1
+    return {
+        "owned_wallets": len(wallet_set),
+        "internal_transfers": internal_count,
+        "external_transfer_in": external_in,
+        "external_transfer_out": external_out,
+    }
+
+
 class TransferMatch:
     __slots__ = ("out_event", "in_event")
 

--- a/sol_cgt/reporting/xlsx.py
+++ b/sol_cgt/reporting/xlsx.py
@@ -149,6 +149,30 @@ def _disposal_rows(disposals: Sequence[DisposalRecord]) -> list[dict[str, str]]:
     return rows
 
 
+
+
+def _internal_transfer_rows(events: Sequence[NormalizedEvent]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for event in sorted(events, key=lambda ev: (ev.ts, ev.raw.get("signature") or ev.id, ev.id)):
+        if not event.raw.get("is_internal_transfer") or event.raw.get("is_internal_transfer_duplicate"):
+            continue
+        token = event.base_token or event.quote_token
+        rows.append(
+            {
+                "timestamp_local": utils.to_au_local(event.ts).isoformat(),
+                "date_local": utils.to_au_local(event.ts).date().isoformat(),
+                "signature": event.raw.get("signature") or event.id.split("#")[0],
+                "from_wallet": event.raw.get("from_wallet") or "",
+                "to_wallet": event.raw.get("to_wallet") or "",
+                "mint": (token.mint if token else event.raw.get("asset_mint") or ""),
+                "symbol": token.symbol if token and token.symbol else "",
+                "amount": event.raw.get("amount") or str(token.amount if token else Decimal("0")),
+                "fee_aud": str(event.raw.get("fee_aud", "0")),
+                "notes": event.raw.get("internal_transfer_reason") or "",
+            }
+        )
+    return rows
+
 def _lot_move_rows(lot_moves: Sequence[LotMoveRecord]) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     for move in lot_moves:
@@ -242,6 +266,15 @@ def export_xlsx(
             wallet_sheet.append([row.get(col) for col in WALLET_SUMMARY_COLUMNS])
         _apply_header_style(wallet_sheet)
         _auto_width(wallet_sheet)
+
+    internal_sheet = workbook.create_sheet("internal_transfers")
+    internal_rows = _internal_transfer_rows(events)
+    if internal_rows:
+        internal_sheet.append(list(internal_rows[0].keys()))
+        for row in internal_rows:
+            internal_sheet.append(list(row.values()))
+        _apply_header_style(internal_sheet)
+        _auto_width(internal_sheet)
 
     lot_moves_sheet = workbook.create_sheet("Lot moves")
     move_rows = _lot_move_rows(lot_moves)

--- a/sol_cgt/tests/test_reporting_outputs.py
+++ b/sol_cgt/tests/test_reporting_outputs.py
@@ -131,6 +131,7 @@ def test_csv_and_xlsx_outputs(tmp_path) -> None:
     assert "Overview" in workbook.sheetnames
     assert "Missing lots" in workbook.sheetnames
     assert "Summary by token" in workbook.sheetnames
+    assert "internal_transfers" in workbook.sheetnames
     assert "Wallet summary" in workbook.sheetnames
     assert [cell.value for cell in workbook["Summary by token"][1]] == SUMMARY_BY_TOKEN_COLUMNS
     assert [cell.value for cell in workbook["Wallet summary"][1]] == WALLET_SUMMARY_COLUMNS

--- a/sol_cgt/tests/test_transfers.py
+++ b/sol_cgt/tests/test_transfers.py
@@ -174,3 +174,31 @@ def test_detect_self_transfers_signature_without_counterparty() -> None:
     assert len(matches) == 1
     assert "self_transfer" in out_event.tags
     assert "self_transfer" in in_event.tags
+
+
+def test_classify_internal_transfers_marks_and_deduplicates() -> None:
+    from sol_cgt.reconciliation.transfers import classify_internal_transfers
+
+    ts = datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
+    out_event = make_transfer("sig1#0", "transfer_out", "W1", 1_000_000, ts, signature="sig1", counterparty="W2")
+    out_event.raw.update({"transfer_from_wallet": "W1", "transfer_to_wallet": "W2"})
+    in_event = make_transfer("sig1#1", "transfer_in", "W2", 1_000_000, ts, signature="sig1", counterparty="W1")
+    in_event.raw.update({"transfer_from_wallet": "W1", "transfer_to_wallet": "W2"})
+
+    stats = classify_internal_transfers([out_event, in_event], wallets=["W1", "W2"])
+    assert stats["internal_transfers"] == 1
+    assert out_event.kind == "transfer_internal"
+    assert in_event.kind == "transfer_internal"
+    assert in_event.raw.get("is_internal_transfer_duplicate") is True
+
+
+def test_classify_internal_transfers_external_remains_external() -> None:
+    from sol_cgt.reconciliation.transfers import classify_internal_transfers
+
+    ts = datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
+    event = make_transfer("sig2#0", "transfer_in", "W1", 1_000_000, ts, signature="sig2", counterparty="EXT")
+    event.raw.update({"transfer_from_wallet": "EXT", "transfer_to_wallet": "W1"})
+    stats = classify_internal_transfers([event], wallets=["W1", "W2"])
+    assert stats["internal_transfers"] == 0
+    assert stats["external_transfer_in"] == 1
+    assert event.kind == "transfer_in"

--- a/sol_cgt/types.py
+++ b/sol_cgt/types.py
@@ -63,6 +63,7 @@ NormalizedEventKind = Literal[
     "buy",
     "transfer_in",
     "transfer_out",
+    "transfer_internal",
     "airdrop",
     "mint",
     "burn",


### PR DESCRIPTION
### Motivation
- Ensure transfers between wallets provided to `solcgt compute` are treated as internal/self-transfers and do not create taxable disposals or new acquisition lots. 
- Preserve cost basis and avoid triggering missing-lot backfill while still surfacing internal transfers for audit.

### Description
- Add `classify_internal_transfers` and `normalize_wallet_address` to `sol_cgt/reconciliation/transfers.py` to mark and deduplicate internal transfers using normalized source/destination metadata and a stable dedupe key. 
- Normalize and deduplicate CLI wallet inputs in `cli._collect_wallets` and invoke `classify_internal_transfers` after normalization and before valuation/accounting (including during backfill loops), emitting the requested summary log line. 
- Introduce `transfer_internal` to `NormalizedEventKind` in `sol_cgt/types.py` and annotate internal events with metadata (`is_internal_transfer`, `internal_transfer_reason`, `from_wallet`, `to_wallet`, `asset_mint`, `amount`) and duplicate markers. 
- Update `AccountingEngine.process` in `sol_cgt/accounting/engine.py` to skip `transfer_internal` events and internal duplicates so they do not produce disposals/acquisitions or trigger missing-lot behavior while preserving fee handling. 
- Add an `internal_transfers` XLSX sheet in `sol_cgt/reporting/xlsx.py` to surface deduplicated internal transfers with timestamp, signature, from/to wallets, mint/symbol, amount, fee, and notes. 
- Add focused unit tests in `sol_cgt/tests/test_transfers.py` and modify `sol_cgt/tests/test_reporting_outputs.py` to validate classification, deduplication, external-transfer non-regression, and XLSX sheet presence.

### Testing
- Ran `pytest -q sol_cgt/tests/test_transfers.py sol_cgt/tests/test_reporting_outputs.py` and both test modules completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8c97e0f483319ad0ed085b125379)