### PR TITLE
Infer SOL/WSOL-based valuations for unsupported SPL swap legs

### DIFF
--- a/sol_cgt/pricing/valuation.py
+++ b/sol_cgt/pricing/valuation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
+import logging
 from typing import Callable, Iterable, Optional
 
 from .. import utils
@@ -11,6 +12,7 @@ from ..types import NormalizedEvent, WarningRecord
 from . import STABLECOIN_MINTS, TimestampPriceProvider, WSOL_MINT, normalize_mint
 
 SOL_MINT = "SOL"
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -55,6 +57,15 @@ def valuate_events(events: Iterable[NormalizedEvent], ctx: ValuationContext) -> 
         else:
             result = valuate_event(event, ctx)
         _attach_result(event, result, ctx)
+    inferred = sum(1 for e in events_list if e.raw.get("valuation_method") == "inferred_from_sol_leg")
+    missing_no_leg = sum(
+        1 for e in events_list
+        if e.raw.get("valuation_method") == "missing_token_price_no_counterparty_leg"
+    )
+    ambiguous = sum(1 for e in events_list if e.raw.get("valuation_method") == "ambiguous_multi_token_swap")
+    LOGGER.info("Inferred swap valuations from SOL legs count=%s", inferred)
+    LOGGER.info("Missing token prices without counterparty leg count=%s", missing_no_leg)
+    LOGGER.info("Ambiguous swap valuations count=%s", ambiguous)
     return ctx.warnings
 
 
@@ -72,13 +83,16 @@ def valuate_event(event: NormalizedEvent, ctx: ValuationContext) -> ValuationRes
         "cost_hint_aud" in event.raw or "cost_hint_usd" in event.raw
     ):
         return ValuationResult(None, None, "hint", "existing cost hint")
+    if event.kind == "transfer_internal" or event.raw.get("is_internal_transfer"):
+        return ValuationResult(None, None, "internal-transfer", "valuation bypassed for internal transfer")
     usd_price = ctx.usd_provider.price_usd(token.mint, event.ts)
     if usd_price is None:
         ctx.warn(
             event,
-            "missing_price",
-            f"Price not available for mint={token.mint} at {event.ts.isoformat()}",
+            "missing_token_price_no_counterparty_leg",
+            f"Price unavailable without counterparty leg for mint={token.mint} at {event.ts.isoformat()}",
         )
+        event.raw["valuation_method"] = "missing_token_price_no_counterparty_leg"
         _mark_unpriced(event)
         return ValuationResult(None, None, "unpriced", "missing timestamp price")
     value_usd = usd_price * token.amount
@@ -140,7 +154,7 @@ def _swap_valuation_map(
 ) -> dict[str, ValuationResult]:
     grouped: dict[tuple[str, str], list[NormalizedEvent]] = {}
     for event in events:
-        if event.kind != "swap":
+        if not isinstance(event.raw.get("swap_legs"), list):
             continue
         signature = event.raw.get("signature") or event.id
         grouped.setdefault((signature, event.wallet), []).append(event)
@@ -151,6 +165,43 @@ def _swap_valuation_map(
         if not isinstance(swap_legs, list):
             continue
         ins, outs = _swap_deltas(swap_legs)
+        token_ins = {m: a for m, a in ins.items() if not _is_sol(m) and not _is_stable(m)}
+        token_outs = {m: a for m, a in outs.items() if not _is_sol(m) and not _is_stable(m)}
+        sol_in_qty = sum((amt for mint, amt in ins.items() if _is_sol(mint)), Decimal("0"))
+        sol_out_qty = sum((amt for mint, amt in outs.items() if _is_sol(mint)), Decimal("0"))
+        if len(token_ins) + len(token_outs) > 1:
+            for event in group:
+                ctx.warn(event, "ambiguous_multi_token_swap", f"valuation_method_unavailable: ambiguous_multi_token_swap signature={signature}")
+                event.raw["valuation_method"] = "ambiguous_multi_token_swap"
+                results[event.id] = ValuationResult(None, None, "unpriced", "ambiguous_multi_token_swap")
+            continue
+        if len(token_ins) + len(token_outs) == 1 and (sol_in_qty > 0 or sol_out_qty > 0):
+            sol_amt = sol_in_qty or sol_out_qty
+            sol_price = ctx.usd_provider.price_usd(SOL_MINT, group[0].ts)
+            if sol_price is not None:
+                total_usd = sol_amt * sol_price
+                fx = ctx.fx_rate(group[0].ts)
+                total_aud = utils.quantize_aud(total_usd * fx)
+                for event in group:
+                    token = event.base_token or event.quote_token
+                    if token is None:
+                        continue
+                    if not _is_sol(token.mint):
+                        event.raw["valuation_method"] = "inferred_from_sol_leg"
+                        event.raw["valuation_reference_asset"] = WSOL_MINT
+                        event.raw["valuation_reference_mint"] = WSOL_MINT
+                        event.raw["valuation_reference_amount"] = str(sol_amt)
+                        event.raw["valuation_reference_price_usd"] = str(sol_price)
+                        event.raw["valuation_fx_usd_aud"] = str(fx)
+                        event.raw["valuation_confidence"] = "high"
+                    if event.base_token is not None:
+                        event.raw.setdefault("proceeds_hint_usd", str(total_usd))
+                        event.raw.setdefault("proceeds_hint_aud", str(total_aud))
+                    elif event.quote_token is not None:
+                        event.raw.setdefault("cost_hint_usd", str(total_usd))
+                        event.raw.setdefault("cost_hint_aud", str(total_aud))
+                    results[event.id] = ValuationResult(total_usd, total_aud, "tx-implied:sol-leg", "SOL/WSOL counterparty inferred")
+                continue
         total_consideration, price_source, notes = _swap_anchor_value(ins, outs, group[0].ts, ctx)
         if total_consideration is None:
             for event in group:

--- a/sol_cgt/reporting/xlsx.py
+++ b/sol_cgt/reporting/xlsx.py
@@ -102,6 +102,10 @@ def _transaction_rows(events: Sequence[NormalizedEvent], price_provider: AudPric
                 "counterparty": event.counterparty or "",
                 "notes": ",".join(sorted(event.tags)) if event.tags else "",
                 "source": event.raw.get("source") or "",
+                "valuation_method": event.raw.get("valuation_method") or "",
+                "valuation_reference_asset": event.raw.get("valuation_reference_asset") or "",
+                "valuation_reference_amount": event.raw.get("valuation_reference_amount") or "",
+                "valuation_confidence": event.raw.get("valuation_confidence") or "",
             }
         )
     return rows

--- a/sol_cgt/tests/test_reporting_outputs.py
+++ b/sol_cgt/tests/test_reporting_outputs.py
@@ -135,6 +135,9 @@ def test_csv_and_xlsx_outputs(tmp_path) -> None:
     assert "Wallet summary" in workbook.sheetnames
     assert [cell.value for cell in workbook["Summary by token"][1]] == SUMMARY_BY_TOKEN_COLUMNS
     assert [cell.value for cell in workbook["Wallet summary"][1]] == WALLET_SUMMARY_COLUMNS
+    tx_headers = [cell.value for cell in workbook["Transactions"][1]]
+    assert "valuation_method" in tx_headers
+    assert "valuation_reference_asset" in tx_headers
 
 
 def test_parquet_requires_extra(monkeypatch, tmp_path) -> None:

--- a/sol_cgt/tests/test_valuation.py
+++ b/sol_cgt/tests/test_valuation.py
@@ -78,3 +78,59 @@ def test_provider_returns_none_for_non_sol_token() -> None:
     provider = TimestampPriceProvider(api_key="key")
     ts = datetime(2024, 8, 1, tzinfo=timezone.utc)
     assert provider.price_usd("TOKENX", ts) is None
+
+
+def test_buy_swap_infers_from_sol_leg_no_token_price_lookup() -> None:
+    ts = datetime(2024, 7, 1, tzinfo=timezone.utc)
+    event = NormalizedEvent(
+        id="sig#1",
+        ts=ts,
+        kind="buy",
+        quote_token=TokenAmount(mint="TOKENX", symbol="TKX", decimals=6, amount_raw=10_000_000_000),
+        fee_sol=Decimal("0"),
+        wallet="WALLET",
+        raw={
+            "signature": "sig",
+            "swap_legs": [
+                {"mint": "So11111111111111111111111111111111111111112", "amount": "0.5", "direction": "out"},
+                {"mint": "TOKENX", "amount": "10000", "direction": "in"},
+            ],
+        },
+    )
+    ctx = valuation_module.ValuationContext(
+        usd_provider=FixedUsdProvider({"SOL": Decimal("100")}),
+        fx_rate=lambda _: Decimal("1.5"),
+    )
+    warnings = valuation_module.valuate_events([event], ctx)
+    assert warnings == []
+    assert Decimal(event.raw["cost_hint_usd"]) == Decimal("50.0")
+    assert Decimal(event.raw["cost_hint_aud"]) == Decimal("75.00")
+    assert event.raw["valuation_method"] == "inferred_from_sol_leg"
+
+
+def test_ambiguous_multi_token_swap_warns() -> None:
+    ts = datetime(2024, 7, 1, tzinfo=timezone.utc)
+    event = NormalizedEvent(
+        id="sig2#1",
+        ts=ts,
+        kind="buy",
+        quote_token=TokenAmount(mint="TOKENX", symbol="TKX", decimals=6, amount_raw=1_000_000),
+        fee_sol=Decimal("0"),
+        wallet="WALLET",
+        raw={
+            "signature": "sig2",
+            "swap_legs": [
+                {"mint": "WSOL", "amount": "0.5", "direction": "out"},
+                {"mint": "TOKENX", "amount": "1", "direction": "in"},
+                {"mint": "TOKENY", "amount": "2", "direction": "in"},
+            ],
+        },
+    )
+    ctx = valuation_module.ValuationContext(
+        usd_provider=FixedUsdProvider({"SOL": Decimal("100")}),
+        fx_rate=lambda _: Decimal("1.0"),
+    )
+    warnings = valuation_module.valuate_events([event], ctx)
+    assert warnings
+    assert warnings[0].code == "ambiguous_multi_token_swap"
+    assert event.raw["valuation_method"] == "ambiguous_multi_token_swap"


### PR DESCRIPTION
### Motivation
- Prevent noisy `Price not available for mint=...` warnings for swap events where a SOL/WSOL leg provides clear consideration and allow AUD valuation to be inferred from the SOL counterparty leg. 

### Description
- Add a transaction-local valuation path that groups events by `raw.swap_legs` (transaction signature + wallet) and, when exactly one non-SOL token leg and one SOL/WSOL leg exist, infers USD/AUD value from the SOL amount using the existing SOL/USD table and FX provider, populating `cost_hint_*` or `proceeds_hint_*` as appropriate. 
- Annotate inferred events with audit metadata such as `valuation_method`, `valuation_reference_mint`, `valuation_reference_amount`, `valuation_reference_price_usd`, `valuation_fx_usd_aud`, and `valuation_confidence`, and avoid calling direct token price lookup for those tokens. 
- Add conservative ambiguity handling that emits a `ambiguous_multi_token_swap` warning and leaves valuation unset for swaps with multiple non-SOL tokens. 
- Bypass valuation for internal transfers (`transfer_internal` / `is_internal_transfer`) and change missing-price warnings for unsupported tokens without a counterparty leg to `missing_token_price_no_counterparty_leg`. 
- Add aggregate info logs summarizing inferred, missing-no-leg, and ambiguous swap counts, and extend XLSX `Transactions` rows with `valuation_method`, `valuation_reference_asset`, `valuation_reference_amount`, and `valuation_confidence`. 

### Testing
- Ran the focused test suite with `pytest -q sol_cgt/tests/test_valuation.py sol_cgt/tests/test_reporting_outputs.py` and all tests in those files passed. 
- Added tests cover inferred buy swaps from SOL legs, ambiguous multi-token swap warnings, and the new report column presence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8eeaeeb88331879536d6d65e5f5a)