### PR TITLE
Fix incomplete CGT outputs from partial cache and lot handling

### DIFF
--- a/sol_cgt/accounting/eligibility.py
+++ b/sol_cgt/accounting/eligibility.py
@@ -28,7 +28,7 @@ def apply_accounting_policy(
     for event in events:
         _classify_event(event)
         reason = _policy_reason(event, sol_dust_threshold, aud_dust_threshold, include_dust)
-        if reason is None:
+        if reason is None and event.raw.get("accounting_action") in {"taxable_acquisition", "taxable_disposal"} and not event.raw.get("swap_component"):
             taxable.append(event)
             continue
         row = _manual_row(event, reason)

--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -186,10 +186,39 @@ def _run_accounting(
     except accounting_methods.LotSelectionError as exc:
         if exc.issue and exc.issue not in missing_lot_issues:
             missing_lot_issues.append(exc.issue)
-        partial = exc.partial_result
-        if not isinstance(partial, AccountingResult):
-            partial = AccountingResult(acquisitions=[], disposals=[], lot_moves=[], warnings=[])
+        if strict_lots:
+            raise
+        partial = exc.partial_result if isinstance(exc.partial_result, AccountingResult) else AccountingResult(acquisitions=[], disposals=[], lot_moves=[], warnings=[])
         return partial, True
+
+
+def _ensure_cache_coverage(wallets: list[str], *, gte_time: Optional[int], lte_time: Optional[int], fetch: bool, settings) -> bool:
+    complete = True
+    for addr in wallets:
+        cache_min, cache_max = fetch_mod.cache_time_bounds(addr)
+        has_data = cache_min is not None and cache_max is not None
+        covers_start = gte_time is None or (has_data and cache_min <= gte_time)
+        covers_end = lte_time is None or (has_data and cache_max >= lte_time)
+        coverage = "complete" if (has_data and covers_start and covers_end) else "incomplete"
+        logger.info("wallet=%s cache_min=%s cache_max=%s requested_start=%s requested_end=%s coverage=%s", addr, cache_min, cache_max, gte_time, lte_time, coverage)
+        if coverage == "complete":
+            continue
+        complete = False
+        if not fetch:
+            continue
+        asyncio.run(
+            fetch_mod.fetch_wallet(
+                addr,
+                api_key=settings.api_keys.helius,
+                base_url=settings.helius_enhanced_base_url,
+                limit=settings.helius_tx_limit,
+                max_pages=settings.helius_max_pages,
+                gte_time=gte_time,
+                lte_time=lte_time,
+                append=True,
+            )
+        )
+    return complete
 
 
 def _collect_wallets(wallet_values: Optional[List[str]]) -> List[str]:
@@ -427,6 +456,9 @@ def compute(
     lte_time = int(fy_period.end.timestamp()) if fy_period else None
     rpc_url = _resolve_rpc_url(settings)
     raw_by_wallet: dict[str, list[dict]] = {}
+    cache_coverage_complete = _ensure_cache_coverage(wallets, gte_time=gte_time, lte_time=lte_time, fetch=fetch, settings=settings)
+    if not cache_coverage_complete and not fetch:
+        raise typer.BadParameter("Cache coverage is incomplete for requested period and --no-fetch was specified.")
     for addr in wallets:
         if not fetch_mod.cache_has_data(addr):
             if fetch:
@@ -576,8 +608,14 @@ def compute(
                     fx_rate=price_provider.fx_rate,
                 ),
             )
+            eligibility = apply_accounting_policy(
+                scoped_events,
+                sol_dust_threshold=sol_dust_threshold_dec,
+                aud_dust_threshold=aud_dust_threshold_dec,
+                include_dust=include_dust,
+            )
             result, stopped_for_missing = _run_accounting(
-                events=scoped_events,
+                events=eligibility.taxable_events,
                 wallets=wallets,
                 settings=settings,
                 price_provider=price_provider,
@@ -660,6 +698,7 @@ def compute(
         output_dir = output_dir / fy_label
     overview_row = {
         "accounting_complete": not bool(excluded_events or missing_lot_issues),
+        "cache_coverage_complete": cache_coverage_complete,
         "taxable_events_processed": len(eligibility.taxable_events),
         "manual_review_events": len(eligibility.manual_review),
         "missing_lot_events": len(missing_lot_issues),
@@ -702,6 +741,8 @@ def compute(
                 "Fees total (AUD)": str(fees_total),
                 "Warnings": str(len(warnings)),
                 "Missing lots": str(len(missing_lot_issues)),
+                "Accounting complete": str(not bool(excluded_events or missing_lot_issues)),
+                "Cache coverage complete": str(cache_coverage_complete),
             },
             events=[ev for ev in scoped_events if not fy_period or fy_period.start <= ev.ts <= fy_period.end],
             lots=acquisitions,
@@ -712,6 +753,15 @@ def compute(
             warnings=warnings,
             missing_lots=missing_lot_issues,
             price_provider=price_provider,
+            transaction_summary=transaction_summary,
+            manual_review=eligibility.manual_review,
+            excluded_events=excluded_events,
+            valuation_warnings=valuation_warning_rows,
+            missing_lot_warnings=[w.model_dump() for w in missing_lot_warnings],
+            taxable_acquisitions=[lot.model_dump() for lot in acquisitions],
+            taxable_disposals=[d.model_dump() for d in disposals],
+            normalized_events_debug=[ev.model_dump() for ev in scoped_events],
+            dust_ignored=eligibility.dust_ignored,
         )
     console_report.render_summary(disposals, acquisitions, warnings)
     typer.echo("Manual review items were excluded from taxable CGT totals.")

--- a/sol_cgt/config.py
+++ b/sol_cgt/config.py
@@ -68,7 +68,7 @@ class AppSettings(BaseSettings):
     treat_liquidity_as_disposal: bool = False
     external_lot_tracking: bool = True
     apply_cgt_discount: bool = False
-    strict_lots: bool = True
+    strict_lots: bool = False
     auto_backfill: bool = False
     backfill_step_days: int = Field(default=30, ge=1)
     max_backfill_days: int = Field(default=3650, ge=1)

--- a/sol_cgt/ingestion/fetch.py
+++ b/sol_cgt/ingestion/fetch.py
@@ -140,3 +140,15 @@ def cache_has_data(wallet: str) -> bool:
     for _ in utils.read_jsonl(path):
         return True
     return False
+
+
+def cache_time_bounds(wallet: str) -> tuple[Optional[int], Optional[int]]:
+    min_ts: Optional[int] = None
+    max_ts: Optional[int] = None
+    for entry in utils.read_jsonl(_wallet_cache_path(wallet)):
+        ts = entry.get("timestamp")
+        if not isinstance(ts, int):
+            continue
+        min_ts = ts if min_ts is None else min(min_ts, ts)
+        max_ts = ts if max_ts is None else max(max_ts, ts)
+    return min_ts, max_ts

--- a/sol_cgt/reporting/summaries.py
+++ b/sol_cgt/reporting/summaries.py
@@ -122,10 +122,11 @@ def build_transaction_summary(events: Iterable[NormalizedEvent]) -> list[dict[st
     rows: list[dict[str, object]] = []
     for signature, sig_events in sorted(by_sig.items()):
         kinds = {e.kind for e in sig_events}
-        if any(e.raw.get("accounting_action") == "manual_review" for e in sig_events):
-            classification = "manual_review"
-        elif "swap" in kinds or any("swap" in str(e.raw.get("classification", "")) for e in sig_events):
+        has_trade = "swap" in kinds or any("swap" in str(e.raw.get("classification", "")) for e in sig_events)
+        if has_trade:
             classification = "trade"
+        elif any(e.raw.get("accounting_action") == "manual_review" for e in sig_events):
+            classification = "mixed_or_ambiguous"
         elif kinds == {"transfer_in"}:
             classification = "deposit"
         elif kinds == {"transfer_out"}:
@@ -146,6 +147,7 @@ def build_transaction_summary(events: Iterable[NormalizedEvent]) -> list[dict[st
                 "timestamp": min(e.ts for e in sig_events).isoformat(),
                 "event_count": len(sig_events),
                 "classification": classification,
+                "review_status": "needs_review" if any(e.raw.get("accounting_action") == "manual_review" for e in sig_events) else "ok",
                 "wallets": ",".join(sorted({e.wallet for e in sig_events})),
             }
         )

--- a/sol_cgt/reporting/xlsx.py
+++ b/sol_cgt/reporting/xlsx.py
@@ -210,6 +210,15 @@ def export_xlsx(
     warnings: Sequence[WarningRecord],
     missing_lots: Sequence[MissingLotIssue],
     price_provider: AudPriceProvider,
+    transaction_summary: Sequence[dict[str, object]] = (),
+    manual_review: Sequence[dict[str, object]] = (),
+    excluded_events: Sequence[dict[str, object]] = (),
+    valuation_warnings: Sequence[dict[str, object]] = (),
+    missing_lot_warnings: Sequence[dict[str, object]] = (),
+    taxable_acquisitions: Sequence[dict[str, object]] = (),
+    taxable_disposals: Sequence[dict[str, object]] = (),
+    normalized_events_debug: Sequence[dict[str, object]] = (),
+    dust_ignored: Sequence[dict[str, object]] = (),
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     workbook = Workbook()
@@ -339,5 +348,26 @@ def export_xlsx(
         missing_sheet.auto_filter.ref = missing_sheet.dimensions
         missing_sheet.freeze_panes = "A3"
         _auto_width(missing_sheet)
+
+    def _write_rows(name: str, rows: Sequence[dict[str, object]]) -> None:
+        sheet = workbook.create_sheet(name)
+        if not rows:
+            return
+        headers = list(rows[0].keys())
+        sheet.append(headers)
+        for row in rows:
+            sheet.append([row.get(h) for h in headers])
+        _apply_header_style(sheet)
+        _auto_width(sheet)
+
+    _write_rows("transaction_summary", transaction_summary)
+    _write_rows("manual_review", manual_review)
+    _write_rows("excluded_events", excluded_events)
+    _write_rows("dust_ignored", dust_ignored)
+    _write_rows("valuation_warnings", valuation_warnings)
+    _write_rows("missing_lot_warnings", missing_lot_warnings)
+    _write_rows("taxable_acquisitions", taxable_acquisitions)
+    _write_rows("taxable_disposals", taxable_disposals)
+    _write_rows("normalized_events_debug", normalized_events_debug)
 
     workbook.save(path)

--- a/sol_cgt/tests/test_compute_fetch.py
+++ b/sol_cgt/tests/test_compute_fetch.py
@@ -57,3 +57,16 @@ def test_compute_fetches_missing_cache_with_fy_filters(monkeypatch) -> None:
     assert captured["wallet"] == "wallet"
     assert captured["kwargs"]["gte_time"] == int(fy_period.start.timestamp())
     assert captured["kwargs"]["lte_time"] == int(fy_period.end.timestamp())
+
+
+def test_no_fetch_fails_on_incomplete_cache_coverage(monkeypatch) -> None:
+    settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
+    monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli.fetch_mod, "cache_time_bounds", lambda _: (1719792000, 1722470399))
+    monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: True)
+    monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda _: [])
+    try:
+        cli.compute(wallet=["wallet"], config=None, outdir=None, method=None, fy="2023-2024", fy_start=None, fy_end=None, fmt="csv", xlsx_path=None, sol_price_csv=None, dry_run=True, fetch=False)
+        assert False, "expected failure"
+    except Exception as exc:
+        assert "incomplete" in str(exc).lower()

--- a/sol_cgt/tests/test_missing_lots.py
+++ b/sol_cgt/tests/test_missing_lots.py
@@ -84,3 +84,39 @@ def test_missing_lot_does_not_stop_later_events() -> None:
     result = engine.process([sell_missing, buy], strict_lots=False, missing_lot_issues=issues)
     assert len(issues) == 1
     assert any(lot.source_event == "tx2#0" for lot in result.acquisitions)
+
+
+def test_missing_lot_does_not_block_later_valid_disposal() -> None:
+    ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    sell_missing = NormalizedEvent(
+        id="tx1#0",
+        ts=ts,
+        kind="sell",
+        base_token=TokenAmount(mint="TOKEN", amount_raw=5, decimals=0, symbol="TKN"),
+        fee_sol=Decimal("0"),
+        wallet="W1",
+        raw={"signature": "sig1", "proceeds_aud": "5"},
+    )
+    buy_sol = NormalizedEvent(
+        id="tx2#0",
+        ts=ts.replace(hour=1),
+        kind="buy",
+        quote_token=TokenAmount(mint="SOL", amount_raw=10, decimals=0, symbol="SOL"),
+        fee_sol=Decimal("0"),
+        wallet="W1",
+        raw={"signature": "sig2", "cost_aud": "10"},
+    )
+    sell_sol = NormalizedEvent(
+        id="tx3#0",
+        ts=ts.replace(hour=2),
+        kind="sell",
+        base_token=TokenAmount(mint="SOL", amount_raw=4, decimals=0, symbol="SOL"),
+        fee_sol=Decimal("0"),
+        wallet="W1",
+        raw={"signature": "sig3", "proceeds_aud": "8"},
+    )
+    engine = AccountingEngine(price_provider=SimplePriceProvider({}))
+    issues: list[MissingLotIssue] = []
+    result = engine.process([sell_missing, buy_sol, sell_sol], strict_lots=False, missing_lot_issues=issues)
+    assert len(issues) == 1
+    assert any(d.event_id == "tx3#0" for d in result.disposals)


### PR DESCRIPTION
### Motivation
- Prevent silently exporting incomplete or partial CGT reports when cache coverage or lot history is missing.
- Make strict-lot behaviour opt-in and ensure non-strict runs continue where safe while marking issues for review.
- Provide clear cache coverage diagnostics and richer XLSX output so report completeness is explicit.

### Description
- Add raw cache timestamp bounds and coverage check: implemented `cache_time_bounds` and `_ensure_cache_coverage` to log `wallet/cache_min/cache_max/requested_start/requested_end/coverage` and fetch missing ranges with `append=True` when needed (changes in `sol_cgt/ingestion/fetch.py` and `sol_cgt/cli.py`).
- Do not export partial accounting from `LotSelectionError`: `_run_accounting` now re-raises when `strict_lots` is True and only returns a partial result when non-strict; strict mode is now opt-in by default (changed `strict_lots` default to `False` in `sol_cgt/config.py`).
- Restrict events passed to the lot engine: `apply_accounting_policy` now only passes events with `accounting_action` of `taxable_acquisition`/`taxable_disposal` and excludes `swap_component` rows so unsafe events are filtered before accounting (`sol_cgt/accounting/eligibility.py`).
- Improve transaction-level classification: `build_transaction_summary` keeps swap signatures classified as `trade` and adds a `review_status` column so manual-review components do not override trade classification (`sol_cgt/reporting/summaries.py`).
- Extend XLSX export with completeness and debug sheets and overview flags: added Overview fields (`accounting_complete`, `cache_coverage_complete`) and new sheets `transaction_summary`, `manual_review`, `excluded_events`, `dust_ignored`, `valuation_warnings`, `missing_lot_warnings`, `taxable_acquisitions`, `taxable_disposals`, and `normalized_events_debug` (`sol_cgt/reporting/xlsx.py` and CLI xlsx wiring).
- Misc: re-applied eligibility filtering during auto-backfill loops, and instrumentation/logging to make cache coverage and missing-lot conditions explicit (CLI changes in `sol_cgt/cli.py`).

### Testing
- Added unit tests for cache coverage and missing-lot flow: `test_no_fetch_fails_on_incomplete_cache_coverage` and regressions ensuring non-strict runs continue to later valid disposals (in `sol_cgt/tests/*`).
- Ran targeted test suite: `pytest -q sol_cgt/tests/test_compute_fetch.py sol_cgt/tests/test_missing_lots.py sol_cgt/tests/test_reporting_outputs.py`, and the tests passed (all dots reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9d992e188331887e4143c986b34b)