### PR TITLE
Validate raw transaction cache coverage before normalization

### DIFF
--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -192,33 +192,67 @@ def _run_accounting(
         return partial, True
 
 
-def _ensure_cache_coverage(wallets: list[str], *, gte_time: Optional[int], lte_time: Optional[int], fetch: bool, settings) -> bool:
+def _ensure_cache_coverage(wallets: list[str], *, gte_time: Optional[int], lte_time: Optional[int], fetch: bool, settings, refresh_raw_cache: bool = False) -> tuple[bool, dict[str, fetch_mod.CacheCoverage]]:
     complete = True
+    coverage_by_wallet: dict[str, fetch_mod.CacheCoverage] = {}
     for addr in wallets:
-        cache_min, cache_max = fetch_mod.cache_time_bounds(addr)
-        has_data = cache_min is not None and cache_max is not None
-        covers_start = gte_time is None or (has_data and cache_min <= gte_time)
-        covers_end = lte_time is None or (has_data and cache_max >= lte_time)
-        coverage = "complete" if (has_data and covers_start and covers_end) else "incomplete"
-        logger.info("wallet=%s cache_min=%s cache_max=%s requested_start=%s requested_end=%s coverage=%s", addr, cache_min, cache_max, gte_time, lte_time, coverage)
-        if coverage == "complete":
-            continue
-        complete = False
-        if not fetch:
-            continue
-        asyncio.run(
-            fetch_mod.fetch_wallet(
-                addr,
-                api_key=settings.api_keys.helius,
-                base_url=settings.helius_enhanced_base_url,
-                limit=settings.helius_tx_limit,
-                max_pages=settings.helius_max_pages,
-                gte_time=gte_time,
-                lte_time=lte_time,
-                append=True,
-            )
-        )
-    return complete
+        attempts = 0
+        while attempts < 3:
+            attempts += 1
+            coverage = fetch_mod.inspect_raw_cache_coverage(addr, gte_time, lte_time)
+            coverage_by_wallet[addr] = coverage
+            logger.info("Raw cache coverage wallet=%s cache_path=%s count=%s cache_min=%s cache_max=%s requested_start=%s requested_end=%s complete=%s", addr, coverage.cache_path, coverage.raw_tx_count, coverage.cache_min_timestamp, coverage.cache_max_timestamp, coverage.requested_start, coverage.requested_end, coverage.coverage_complete)
+            if coverage.coverage_complete and not refresh_raw_cache:
+                break
+            if not fetch:
+                break
+            ranges = coverage.missing_ranges or []
+            if refresh_raw_cache and gte_time is not None and lte_time is not None:
+                ranges = [{"start": gte_time, "end": lte_time, "reason": "refresh"}]
+            if not ranges:
+                break
+            had_additions = False
+            for missing in ranges:
+                start = int(missing["start"])
+                end = int(missing["end"])
+                reason = str(missing.get("reason", "unknown"))
+                logger.info("Raw cache missing range wallet=%s start=%s end=%s reason=%s", addr, start, end, reason)
+                before_count = len(fetch_mod.load_cached(addr))
+                asyncio.run(
+                    fetch_mod.fetch_wallet(
+                        addr,
+                        api_key=settings.api_keys.helius,
+                        base_url=settings.helius_enhanced_base_url,
+                        limit=settings.helius_tx_limit,
+                        max_pages=settings.helius_max_pages,
+                        gte_time=start,
+                        lte_time=end,
+                        append=True,
+                    )
+                )
+                after_count = len(fetch_mod.load_cached(addr))
+                added = max(0, after_count - before_count)
+                had_additions = had_additions or added > 0
+                logger.info("Raw cache fetch complete wallet=%s added=%s total=%s", addr, added, after_count)
+            if not had_additions:
+                break
+        coverage = fetch_mod.inspect_raw_cache_coverage(addr, gte_time, lte_time)
+        coverage_by_wallet[addr] = coverage
+        logger.info("Raw cache coverage verified wallet=%s complete=%s count=%s cache_min=%s cache_max=%s", addr, coverage.coverage_complete, coverage.raw_tx_count, coverage.cache_min_timestamp, coverage.cache_max_timestamp)
+        if not coverage.coverage_complete:
+            complete = False
+            if not fetch:
+                logger.error(
+                    "Incomplete raw cache coverage wallet=%s cache_path=%s cache_min=%s cache_max=%s requested_start=%s requested_end=%s missing_ranges=%s rerun without --no-fetch or refresh cache",
+                    addr,
+                    coverage.cache_path,
+                    coverage.cache_min_timestamp,
+                    coverage.cache_max_timestamp,
+                    coverage.requested_start,
+                    coverage.requested_end,
+                    coverage.missing_ranges,
+                )
+    return complete, coverage_by_wallet
 
 
 def _collect_wallets(wallet_values: Optional[List[str]]) -> List[str]:
@@ -401,6 +435,7 @@ def compute(
         "--fetch/--no-fetch",
         help="Fetch txs from Helius if cache is empty or missing",
     ),
+    refresh_raw_cache: bool = typer.Option(False, "--refresh-raw-cache", help="Refetch requested raw transaction window even if cache appears complete"),
     prefetch_mints: bool = typer.Option(
         True,
         "--prefetch-mints/--no-prefetch-mints",
@@ -456,11 +491,11 @@ def compute(
     lte_time = int(fy_period.end.timestamp()) if fy_period else None
     rpc_url = _resolve_rpc_url(settings)
     raw_by_wallet: dict[str, list[dict]] = {}
-    cache_coverage_complete = _ensure_cache_coverage(wallets, gte_time=gte_time, lte_time=lte_time, fetch=fetch, settings=settings)
+    cache_coverage_complete, coverage_by_wallet = _ensure_cache_coverage(wallets, gte_time=gte_time, lte_time=lte_time, fetch=fetch, settings=settings, refresh_raw_cache=refresh_raw_cache)
     if not cache_coverage_complete and not fetch:
-        raise typer.BadParameter("Cache coverage is incomplete for requested period and --no-fetch was specified.")
+        raise typer.BadParameter("Cache coverage is incomplete for requested period and --no-fetch was specified. See logs for wallet cache min/max and missing ranges.")
     for addr in wallets:
-        if not fetch_mod.cache_has_data(addr):
+        if not coverage_by_wallet.get(addr) or coverage_by_wallet[addr].raw_tx_count == 0:
             if fetch:
                 asyncio.run(
                     fetch_mod.fetch_wallet(
@@ -696,9 +731,16 @@ def compute(
     output_dir = outdir or Path("./reports") / ("combined" if len(wallets) > 1 else wallets[0])
     if fy_label:
         output_dir = output_dir / fy_label
+    incomplete_wallets = [w for w, c in coverage_by_wallet.items() if not c.coverage_complete]
     overview_row = {
         "accounting_complete": not bool(excluded_events or missing_lot_issues),
         "cache_coverage_complete": cache_coverage_complete,
+        "cache_coverage_checked": True,
+        "wallets_with_incomplete_cache": ",".join(incomplete_wallets),
+        "raw_tx_count_by_wallet": utils.json_dumps({w: c.raw_tx_count for w, c in coverage_by_wallet.items()}),
+        "cache_min_by_wallet": utils.json_dumps({w: c.cache_min_timestamp for w, c in coverage_by_wallet.items()}),
+        "cache_max_by_wallet": utils.json_dumps({w: c.cache_max_timestamp for w, c in coverage_by_wallet.items()}),
+        "missing_ranges_by_wallet": utils.json_dumps({w: c.missing_ranges for w, c in coverage_by_wallet.items()}),
         "taxable_events_processed": len(eligibility.taxable_events),
         "manual_review_events": len(eligibility.manual_review),
         "missing_lot_events": len(missing_lot_issues),

--- a/sol_cgt/ingestion/fetch.py
+++ b/sol_cgt/ingestion/fetch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -12,6 +13,24 @@ from ..providers import helius
 RAW_CACHE_DIR = utils.ensure_cache_dir("raw")
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheCoverage:
+    wallet: str
+    cache_path: str
+    has_cache: bool
+    raw_tx_count: int
+    cache_min_timestamp: Optional[int]
+    cache_max_timestamp: Optional[int]
+    requested_start: Optional[int]
+    requested_end: Optional[int]
+    covers_start: bool
+    covers_end: bool
+    coverage_complete: bool
+    missing_ranges: list[dict[str, int | str]]
+    malformed_rows: int = 0
+    provider_checked_ranges: list[dict[str, int | str]] | None = None
 
 
 def _wallet_cache_path(wallet: str) -> Path:
@@ -152,3 +171,63 @@ def cache_time_bounds(wallet: str) -> tuple[Optional[int], Optional[int]]:
         min_ts = ts if min_ts is None else min(min_ts, ts)
         max_ts = ts if max_ts is None else max(max_ts, ts)
     return min_ts, max_ts
+
+
+def inspect_raw_cache_coverage(wallet: str, requested_start: Optional[int], requested_end: Optional[int]) -> CacheCoverage:
+    path = _wallet_cache_path(wallet)
+    min_ts: Optional[int] = None
+    max_ts: Optional[int] = None
+    raw_tx_count = 0
+    malformed_rows = 0
+    seen_signatures: set[str] = set()
+    has_cache = path.exists()
+    for entry in utils.read_jsonl(path):
+        if not isinstance(entry, dict):
+            malformed_rows += 1
+            continue
+        signature = entry.get("signature") or entry.get("id")
+        if isinstance(signature, str):
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+        raw_tx_count += 1
+        ts = entry.get("timestamp")
+        if not isinstance(ts, int):
+            ts = entry.get("blockTime")
+        if not isinstance(ts, int):
+            malformed_rows += 1
+            continue
+        min_ts = ts if min_ts is None else min(min_ts, ts)
+        max_ts = ts if max_ts is None else max(max_ts, ts)
+    covers_start = requested_start is None or (min_ts is not None and min_ts <= requested_start)
+    covers_end = requested_end is None or (max_ts is not None and max_ts >= requested_end)
+    coverage_complete = bool(raw_tx_count) and covers_start and covers_end and malformed_rows == 0
+    missing_ranges: list[dict[str, int | str]] = []
+    if raw_tx_count == 0:
+        if requested_start is not None and requested_end is not None:
+            missing_ranges.append({"start": requested_start, "end": requested_end, "reason": "empty_cache"})
+    else:
+        if requested_start is not None and (min_ts is None or min_ts > requested_start):
+            missing_ranges.append({"start": requested_start, "end": min_ts or requested_end or requested_start, "reason": "missing_start"})
+        if requested_end is not None and (max_ts is None or max_ts < requested_end):
+            missing_ranges.append({"start": max_ts or requested_start or requested_end, "end": requested_end, "reason": "missing_end"})
+    if malformed_rows > 0 and requested_start is not None and requested_end is not None:
+        coverage_complete = False
+        if not missing_ranges:
+            missing_ranges.append({"start": requested_start, "end": requested_end, "reason": "malformed_or_missing_timestamps"})
+    return CacheCoverage(
+        wallet=wallet,
+        cache_path=str(path),
+        has_cache=has_cache,
+        raw_tx_count=raw_tx_count,
+        cache_min_timestamp=min_ts,
+        cache_max_timestamp=max_ts,
+        requested_start=requested_start,
+        requested_end=requested_end,
+        covers_start=covers_start,
+        covers_end=covers_end,
+        coverage_complete=coverage_complete,
+        missing_ranges=missing_ranges,
+        malformed_rows=malformed_rows,
+        provider_checked_ranges=[],
+    )

--- a/sol_cgt/tests/test_cache_coverage.py
+++ b/sol_cgt/tests/test_cache_coverage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from sol_cgt import utils
+from sol_cgt.ingestion import fetch
+
+
+def test_inspect_empty_cache_incomplete(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    c = fetch.inspect_raw_cache_coverage("w", 10, 20)
+    assert not c.coverage_complete
+    assert c.missing_ranges[0]["reason"] == "empty_cache"
+
+
+def test_inspect_full_coverage_complete(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 10}, {"signature": "b", "timestamp": 20}], mode="w")
+    c = fetch.inspect_raw_cache_coverage("w", 12, 19)
+    assert c.coverage_complete
+
+
+def test_inspect_missing_start_end(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 15}, {"signature": "b", "timestamp": 16}], mode="w")
+    c = fetch.inspect_raw_cache_coverage("w", 10, 20)
+    reasons = {r["reason"] for r in c.missing_ranges}
+    assert "missing_start" in reasons
+    assert "missing_end" in reasons
+
+
+def test_inspect_malformed_incomplete(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a"}, {"signature": "b", "blockTime": 18}], mode="w")
+    c = fetch.inspect_raw_cache_coverage("w", 10, 20)
+    assert not c.coverage_complete
+    assert c.malformed_rows > 0
+
+
+def test_inspect_dedup_signature_not_double_count(tmp_path, monkeypatch):
+    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 10}, {"signature": "a", "timestamp": 10}], mode="w")
+    c = fetch.inspect_raw_cache_coverage("w", 10, 10)
+    assert c.raw_tx_count == 1

--- a/sol_cgt/tests/test_compute_fetch.py
+++ b/sol_cgt/tests/test_compute_fetch.py
@@ -5,7 +5,24 @@ from sol_cgt.config import APIKeys, AppSettings
 def test_compute_fetches_missing_cache_with_fy_filters(monkeypatch) -> None:
     settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
     monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
-    monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: False)
+    monkeypatch.setattr(
+        cli.fetch_mod,
+        "inspect_raw_cache_coverage",
+        lambda wallet, start, end: cli.fetch_mod.CacheCoverage(
+            wallet=wallet,
+            cache_path=f"{wallet}.jsonl",
+            has_cache=False,
+            raw_tx_count=0,
+            cache_min_timestamp=None,
+            cache_max_timestamp=None,
+            requested_start=start,
+            requested_end=end,
+            covers_start=False,
+            covers_end=False,
+            coverage_complete=False,
+            missing_ranges=[{"start": start, "end": end, "reason": "empty_cache"}],
+        ),
+    )
 
     captured: dict[str, object] = {}
 
@@ -62,8 +79,24 @@ def test_compute_fetches_missing_cache_with_fy_filters(monkeypatch) -> None:
 def test_no_fetch_fails_on_incomplete_cache_coverage(monkeypatch) -> None:
     settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
     monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
-    monkeypatch.setattr(cli.fetch_mod, "cache_time_bounds", lambda _: (1719792000, 1722470399))
-    monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: True)
+    monkeypatch.setattr(
+        cli.fetch_mod,
+        "inspect_raw_cache_coverage",
+        lambda wallet, start, end: cli.fetch_mod.CacheCoverage(
+            wallet=wallet,
+            cache_path=f"{wallet}.jsonl",
+            has_cache=True,
+            raw_tx_count=1,
+            cache_min_timestamp=1719792000,
+            cache_max_timestamp=1722470399,
+            requested_start=start,
+            requested_end=end,
+            covers_start=False,
+            covers_end=False,
+            coverage_complete=False,
+            missing_ranges=[{"start": start, "end": 1719792000, "reason": "missing_start"}],
+        ),
+    )
     monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda _: [])
     try:
         cli.compute(wallet=["wallet"], config=None, outdir=None, method=None, fy="2023-2024", fy_start=None, fy_end=None, fmt="csv", xlsx_path=None, sol_price_csv=None, dry_run=True, fetch=False)

--- a/sol_cgt/tests/test_raw_export.py
+++ b/sol_cgt/tests/test_raw_export.py
@@ -9,8 +9,25 @@ from sol_cgt.config import APIKeys, AppSettings
 def test_compute_writes_combined_raw_transactions_before_price_warmup(monkeypatch, tmp_path: Path) -> None:
     settings = AppSettings(wallets=["wallet1", "wallet2"], api_keys=APIKeys(helius="key"))
     monkeypatch.setattr(cli, "load_settings", lambda *args, **kwargs: settings)
-    monkeypatch.setattr(cli.fetch_mod, "cache_has_data", lambda _: True)
     monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda w: [{"signature": f"{w}-sig", "blockTime": 1}])
+    monkeypatch.setattr(
+        cli.fetch_mod,
+        "inspect_raw_cache_coverage",
+        lambda wallet, start, end: cli.fetch_mod.CacheCoverage(
+            wallet=wallet,
+            cache_path=f"{wallet}.jsonl",
+            has_cache=True,
+            raw_tx_count=1,
+            cache_min_timestamp=start,
+            cache_max_timestamp=end,
+            requested_start=start,
+            requested_end=end,
+            covers_start=True,
+            covers_end=True,
+            coverage_complete=True,
+            missing_ranges=[],
+        ),
+    )
 
     order: list[str] = []
 


### PR DESCRIPTION
### Motivation
- Prevent normalization and accounting from trusting a partial raw transaction cache that does not fully cover the requested reporting period. 
- Ensure missing raw ranges are fetched (when allowed) so acquisitions/disposals and cost-basis calculations are not silently omitted.

### Description
- Added `CacheCoverage` dataclass and `inspect_raw_cache_coverage(wallet, requested_start, requested_end)` to `sol_cgt.ingestion.fetch` which inspects cached Helius raw entries (checks `timestamp` and fallback `blockTime`) and reports counts, min/max timestamps, malformed rows, and `missing_ranges` while deduplicating by signature.
- Updated compute flow in `sol_cgt.cli` to call the inspector for every wallet before loading/exporting/normalization, fetch any `missing_ranges` (with bounded attempts), re-inspect coverage, and refuse to proceed silently when coverage remains incomplete and fetch is disabled.
- Added `--refresh-raw-cache` option to force refetching the requested raw window regardless of apparent coverage, and added logs for inspect/missing/fetch/verified phases to help diagnose incomplete cache states.
- Enriched report overview with cache coverage metadata fields including `cache_coverage_checked`, `wallets_with_incomplete_cache`, `raw_tx_count_by_wallet`, `cache_min_by_wallet`, `cache_max_by_wallet`, and `missing_ranges_by_wallet`.

### Testing
- Added `sol_cgt/tests/test_cache_coverage.py` with unit tests for empty cache, full coverage, missing start/end ranges, malformed rows, and signature deduplication, and updated `test_compute_fetch.py` and `test_raw_export.py` to exercise the new inspection/fetch flow. 
- Ran the targeted test suite: `pytest -q sol_cgt/tests/test_cache_coverage.py sol_cgt/tests/test_compute_fetch.py sol_cgt/tests/test_raw_export.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9ea04a088331a5e748ec1f8e43dd)