### PR TITLE
Fix XLSX export crash when debug rows include objects

### DIFF
--- a/sol_cgt/reporting/xlsx.py
+++ b/sol_cgt/reporting/xlsx.py
@@ -197,6 +197,18 @@ def _lot_move_rows(lot_moves: Sequence[LotMoveRecord]) -> list[dict[str, str]]:
     return rows
 
 
+def _excel_safe(value: object) -> object:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        return utils.json_dumps(value)
+    return value
+
+
 def export_xlsx(
     path: Path,
     *,
@@ -305,10 +317,7 @@ def export_xlsx(
         for warning in warnings:
             row = []
             for value in warning.model_dump().values():
-                if hasattr(value, "isoformat"):
-                    row.append(value.isoformat())
-                else:
-                    row.append(value)
+                row.append(_excel_safe(value))
             warnings_sheet.append(row)
         _apply_header_style(warnings_sheet)
         _auto_width(warnings_sheet)
@@ -338,10 +347,7 @@ def export_xlsx(
             row = []
             for key in columns:
                 value = payload.get(key)
-                if hasattr(value, "isoformat"):
-                    row.append(value.isoformat())
-                else:
-                    row.append(value)
+                row.append(_excel_safe(value))
             missing_sheet.append(row)
         bold = Font(bold=True)
         for cell in missing_sheet[2]:
@@ -357,7 +363,7 @@ def export_xlsx(
         headers = list(rows[0].keys())
         sheet.append(headers)
         for row in rows:
-            sheet.append([row.get(h) for h in headers])
+            sheet.append([_excel_safe(row.get(h)) for h in headers])
         _apply_header_style(sheet)
         _auto_width(sheet)
 


### PR DESCRIPTION
### Motivation
- Prevent `openpyxl` from raising `ValueError` when a cell value is a non-primitive (for example a nested token dict) while exporting debug sheets.
- Make XLSX exports of `normalized_events_debug`, warnings, and missing-lot reports robust to nested objects without changing numeric formatting logic.

### Description
- Add `_excel_safe(value)` helper in `sol_cgt/reporting/xlsx.py` to normalize values by converting datetimes with `isoformat()`, `Decimal` to `str()`, and containers (`dict`, `list`, `tuple`, `set`) to JSON via `utils.json_dumps()` while preserving `None`.
- Use `_excel_safe` when writing `Warnings` and `Missing lots` rows and in the generic `_write_rows` writer so all debug and auxiliary sheets are serialized safely.
- Keep existing formatting and numeric conversions untouched; serialization changes are limited to preparing cell values for Excel.

### Testing
- Ran the test suite with `pytest -q`, which reported multiple pre-existing unrelated failures (CLI cache-coverage behavior, async test plugin availability, and pricing test mocks), so the overall run failed.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa40133908331a6cd4690e99ceb89)