### PR TITLE
Honor provider-exhaustive checks for raw cache coverage and avoid refresh loops

### DIFF
--- a/sol_cgt/cli.py
+++ b/sol_cgt/cli.py
@@ -218,7 +218,7 @@ def _ensure_cache_coverage(wallets: list[str], *, gte_time: Optional[int], lte_t
                 reason = str(missing.get("reason", "unknown"))
                 logger.info("Raw cache missing range wallet=%s start=%s end=%s reason=%s", addr, start, end, reason)
                 before_count = len(fetch_mod.load_cached(addr))
-                asyncio.run(
+                rows = asyncio.run(
                     fetch_mod.fetch_wallet(
                         addr,
                         api_key=settings.api_keys.helius,
@@ -234,11 +234,29 @@ def _ensure_cache_coverage(wallets: list[str], *, gte_time: Optional[int], lte_t
                 added = max(0, after_count - before_count)
                 had_additions = had_additions or added > 0
                 logger.info("Raw cache fetch complete wallet=%s added=%s total=%s", addr, added, after_count)
+                if refresh_raw_cache and reason == "refresh":
+                    checked = fetch_mod.get_provider_checked_ranges(addr)
+                    if checked:
+                        latest = checked[-1]
+                        logger.info(
+                            "Raw provider range verified wallet=%s provider=%s start=%s end=%s exhausted=%s rows=%s unique=%s earliest_returned=%s latest_returned=%s",
+                            addr,
+                            latest.get("provider"),
+                            latest.get("checked_start"),
+                            latest.get("checked_end"),
+                            latest.get("exhausted"),
+                            latest.get("rows_returned"),
+                            latest.get("unique_signatures"),
+                            latest.get("earliest_returned_timestamp"),
+                            latest.get("latest_returned_timestamp"),
+                        )
             if not had_additions:
+                break
+            if refresh_raw_cache:
                 break
         coverage = fetch_mod.inspect_raw_cache_coverage(addr, gte_time, lte_time)
         coverage_by_wallet[addr] = coverage
-        logger.info("Raw cache coverage verified wallet=%s complete=%s count=%s cache_min=%s cache_max=%s", addr, coverage.coverage_complete, coverage.raw_tx_count, coverage.cache_min_timestamp, coverage.cache_max_timestamp)
+        logger.info("Raw cache coverage verified wallet=%s complete=%s reason=%s count=%s cache_min=%s cache_max=%s", addr, coverage.coverage_complete, coverage.coverage_complete_reason, coverage.raw_tx_count, coverage.cache_min_timestamp, coverage.cache_max_timestamp)
         if not coverage.coverage_complete:
             complete = False
             if not fetch:
@@ -742,6 +760,16 @@ def compute(
             reconciliation_summary[0]["expected_transaction_count"] = expected_transaction_count
             reconciliation_summary[0]["expected_count_delta"] = delta
             reconciliation_summary[0]["reconciliation_status"] = "ok" if delta == 0 else "mismatch"
+        if coverage_by_wallet:
+            first_wallet = wallets[0]
+            checked = coverage_by_wallet[first_wallet].provider_checked_ranges or []
+            latest = checked[-1] if checked else {}
+            reconciliation_summary[0]["provider_checked_start"] = latest.get("checked_start")
+            reconciliation_summary[0]["provider_checked_end"] = latest.get("checked_end")
+            reconciliation_summary[0]["provider_exhausted"] = latest.get("exhausted")
+            reconciliation_summary[0]["coverage_complete_reason"] = coverage_by_wallet[first_wallet].coverage_complete_reason
+            reconciliation_summary[0]["earliest_returned_timestamp"] = latest.get("earliest_returned_timestamp")
+            reconciliation_summary[0]["latest_returned_timestamp"] = latest.get("latest_returned_timestamp")
     excluded_events = [*eligibility.manual_review, *eligibility.dust_ignored]
     summary_by_token = summaries.summarize_by_token(disposals)
     summary_overall = summaries.summarize_overall(disposals)

--- a/sol_cgt/ingestion/fetch.py
+++ b/sol_cgt/ingestion/fetch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import json
 import logging
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -14,6 +15,7 @@ from ..providers import helius
 RAW_CACHE_DIR = utils.ensure_cache_dir("raw")
 
 logger = logging.getLogger(__name__)
+PROVIDER_CHECKED_RANGES_PATH = RAW_CACHE_DIR / "provider_checked_ranges.json"
 
 
 @dataclass
@@ -27,6 +29,7 @@ class FetchStats:
     duplicate_signatures: int
     earliest_timestamp: Optional[int]
     latest_timestamp: Optional[int]
+    exhausted: bool = False
 
 
 @dataclass
@@ -45,6 +48,60 @@ class CacheCoverage:
     missing_ranges: list[dict[str, int | str]]
     malformed_rows: int = 0
     provider_checked_ranges: list[dict[str, int | str]] | None = None
+    coverage_complete_reason: str | None = None
+
+
+_PROVIDER_CHECKED_RANGES_IN_MEMORY: dict[str, list[dict[str, int | str | bool | None]]] = {}
+
+
+def _provider_checked_key(wallet: str, provider: str, token_accounts_mode: str) -> str:
+    return f"{wallet}|{provider}|{token_accounts_mode}"
+
+
+def _load_provider_checked_ranges() -> dict[str, list[dict[str, int | str | bool | None]]]:
+    if not PROVIDER_CHECKED_RANGES_PATH.exists():
+        return {}
+    with PROVIDER_CHECKED_RANGES_PATH.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return data if isinstance(data, dict) else {}
+
+
+def _persist_provider_checked_ranges() -> None:
+    existing = _load_provider_checked_ranges()
+    existing.update(_PROVIDER_CHECKED_RANGES_IN_MEMORY)
+    PROVIDER_CHECKED_RANGES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with PROVIDER_CHECKED_RANGES_PATH.open("w", encoding="utf-8") as fh:
+        json.dump(existing, fh)
+
+
+def record_provider_checked_range(wallet: str, provider: str, token_accounts_mode: str, checked_start: int, checked_end: int, pages: int, rows_returned: int, unique_signatures: int, earliest_returned_timestamp: Optional[int], latest_returned_timestamp: Optional[int], exhausted: bool) -> dict[str, int | str | bool | None]:
+    row: dict[str, int | str | bool | None] = {
+        "wallet": wallet,
+        "provider": provider,
+        "token_accounts_mode": token_accounts_mode,
+        "checked_start": checked_start,
+        "checked_end": checked_end,
+        "pages": pages,
+        "rows_returned": rows_returned,
+        "unique_signatures": unique_signatures,
+        "earliest_returned_timestamp": earliest_returned_timestamp,
+        "latest_returned_timestamp": latest_returned_timestamp,
+        "exhausted": exhausted,
+    }
+    key = _provider_checked_key(wallet, provider, token_accounts_mode)
+    _PROVIDER_CHECKED_RANGES_IN_MEMORY.setdefault(key, []).append(row)
+    _persist_provider_checked_ranges()
+    return row
+
+
+def get_provider_checked_ranges(wallet: str) -> list[dict[str, int | str | bool | None]]:
+    combined = _load_provider_checked_ranges()
+    combined.update(_PROVIDER_CHECKED_RANGES_IN_MEMORY)
+    rows: list[dict[str, int | str | bool | None]] = []
+    for key, values in combined.items():
+        if key.split("|", 1)[0] == wallet:
+            rows.extend(values)
+    return rows
 
 
 def _wallet_cache_path(wallet: str) -> Path:
@@ -89,6 +146,7 @@ async def fetch_wallet(
     if provider not in {"enhanced", "getTransactionsForAddress", "auto"}:
         raise RuntimeError(f"Unsupported Helius history provider: {provider}")
     selected_provider = "enhanced" if provider == "auto" else provider
+    exhausted = False
     for page_idx in range(max_pages):
         if gte_time is None or lte_time is None:
             raise RuntimeError("fetch_wallet requires gte_time and lte_time")
@@ -121,6 +179,7 @@ async def fetch_wallet(
             cursor = str(page[-1].get("signature")) if page and page[-1].get("signature") else None
         if not page:
             logger.info("No more transactions for wallet=%s after page=%s", wallet, page_idx + 1)
+            exhausted = True
             break
         all_txs.extend(page)
         rows_returned += len(page)
@@ -175,6 +234,20 @@ async def fetch_wallet(
         max_ts,
         path,
     )
+    if gte_time is not None and lte_time is not None:
+        record_provider_checked_range(
+            wallet,
+            selected_provider,
+            token_accounts,
+            gte_time,
+            lte_time,
+            page_idx + 1 if all_txs else 0,
+            rows_returned,
+            unique_signatures,
+            min_ts,
+            max_ts,
+            exhausted,
+        )
     return deduped
 
 
@@ -279,7 +352,10 @@ def inspect_raw_cache_coverage(wallet: str, requested_start: Optional[int], requ
         max_ts = ts if max_ts is None else max(max_ts, ts)
     covers_start = requested_start is None or (min_ts is not None and min_ts <= requested_start)
     covers_end = requested_end is None or (max_ts is not None and max_ts >= requested_end)
+    coverage_complete_reason: Optional[str] = None
     coverage_complete = bool(raw_tx_count) and covers_start and covers_end and malformed_rows == 0
+    if coverage_complete:
+        coverage_complete_reason = "timestamp_span"
     missing_ranges: list[dict[str, int | str]] = []
     if raw_tx_count == 0:
         if requested_start is not None and requested_end is not None:
@@ -293,6 +369,18 @@ def inspect_raw_cache_coverage(wallet: str, requested_start: Optional[int], requ
         coverage_complete = False
         if not missing_ranges:
             missing_ranges.append({"start": requested_start, "end": requested_end, "reason": "malformed_or_missing_timestamps"})
+    provider_checked_ranges = get_provider_checked_ranges(wallet)
+    if not coverage_complete and requested_start is not None and requested_end is not None and malformed_rows == 0:
+        for row in provider_checked_ranges:
+            if not row.get("exhausted"):
+                continue
+            checked_start = row.get("checked_start")
+            checked_end = row.get("checked_end")
+            if isinstance(checked_start, int) and isinstance(checked_end, int) and checked_start <= requested_start and checked_end >= requested_end:
+                coverage_complete = True
+                coverage_complete_reason = "provider_checked_range"
+                missing_ranges = []
+                break
     return CacheCoverage(
         wallet=wallet,
         cache_path=str(path),
@@ -307,5 +395,6 @@ def inspect_raw_cache_coverage(wallet: str, requested_start: Optional[int], requ
         coverage_complete=coverage_complete,
         missing_ranges=missing_ranges,
         malformed_rows=malformed_rows,
-        provider_checked_ranges=[],
+        provider_checked_ranges=provider_checked_ranges,
+        coverage_complete_reason=coverage_complete_reason,
     )

--- a/sol_cgt/tests/test_cache_coverage.py
+++ b/sol_cgt/tests/test_cache_coverage.py
@@ -4,22 +4,28 @@ from sol_cgt import utils
 from sol_cgt.ingestion import fetch
 
 
-def test_inspect_empty_cache_incomplete(tmp_path, monkeypatch):
+def _set_cache_paths(monkeypatch, tmp_path):
     monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(fetch, "PROVIDER_CHECKED_RANGES_PATH", tmp_path / "provider_checked_ranges.json")
+    monkeypatch.setattr(fetch, "_PROVIDER_CHECKED_RANGES_IN_MEMORY", {})
+
+
+def test_inspect_empty_cache_incomplete(tmp_path, monkeypatch):
+    _set_cache_paths(monkeypatch, tmp_path)
     c = fetch.inspect_raw_cache_coverage("w", 10, 20)
     assert not c.coverage_complete
     assert c.missing_ranges[0]["reason"] == "empty_cache"
 
 
 def test_inspect_full_coverage_complete(tmp_path, monkeypatch):
-    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    _set_cache_paths(monkeypatch, tmp_path)
     utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 10}, {"signature": "b", "timestamp": 20}], mode="w")
     c = fetch.inspect_raw_cache_coverage("w", 12, 19)
     assert c.coverage_complete
 
 
 def test_inspect_missing_start_end(tmp_path, monkeypatch):
-    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    _set_cache_paths(monkeypatch, tmp_path)
     utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 15}, {"signature": "b", "timestamp": 16}], mode="w")
     c = fetch.inspect_raw_cache_coverage("w", 10, 20)
     reasons = {r["reason"] for r in c.missing_ranges}
@@ -28,7 +34,7 @@ def test_inspect_missing_start_end(tmp_path, monkeypatch):
 
 
 def test_inspect_malformed_incomplete(tmp_path, monkeypatch):
-    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    _set_cache_paths(monkeypatch, tmp_path)
     utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a"}, {"signature": "b", "blockTime": 18}], mode="w")
     c = fetch.inspect_raw_cache_coverage("w", 10, 20)
     assert not c.coverage_complete
@@ -36,7 +42,37 @@ def test_inspect_malformed_incomplete(tmp_path, monkeypatch):
 
 
 def test_inspect_dedup_signature_not_double_count(tmp_path, monkeypatch):
-    monkeypatch.setattr(fetch, "RAW_CACHE_DIR", tmp_path)
+    _set_cache_paths(monkeypatch, tmp_path)
     utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 10}, {"signature": "a", "timestamp": 10}], mode="w")
     c = fetch.inspect_raw_cache_coverage("w", 10, 10)
     assert c.raw_tx_count == 1
+
+
+def test_provider_checked_range_marks_complete_even_if_cache_min_gt_start(tmp_path, monkeypatch):
+    _set_cache_paths(monkeypatch, tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 20}], mode="w")
+    fetch.record_provider_checked_range("w", "enhanced", "balanceChanged", 10, 30, 1, 1, 1, 20, 20, True)
+    c = fetch.inspect_raw_cache_coverage("w", 10, 30)
+    assert c.coverage_complete
+    assert c.coverage_complete_reason == "provider_checked_range"
+
+
+def test_provider_checked_zero_rows_exhausted_is_complete(tmp_path, monkeypatch):
+    _set_cache_paths(monkeypatch, tmp_path)
+    fetch.record_provider_checked_range("w", "enhanced", "balanceChanged", 10, 30, 1, 0, 0, None, None, True)
+    c = fetch.inspect_raw_cache_coverage("w", 10, 30)
+    assert c.coverage_complete
+
+
+def test_cache_min_gt_start_without_provider_checked_still_incomplete(tmp_path, monkeypatch):
+    _set_cache_paths(monkeypatch, tmp_path)
+    utils.write_jsonl(tmp_path / "w.jsonl", [{"signature": "a", "timestamp": 20}], mode="w")
+    c = fetch.inspect_raw_cache_coverage("w", 10, 30)
+    assert not c.coverage_complete
+
+
+def test_provider_checked_not_exhausted_is_not_complete(tmp_path, monkeypatch):
+    _set_cache_paths(monkeypatch, tmp_path)
+    fetch.record_provider_checked_range("w", "enhanced", "balanceChanged", 10, 30, 1, 0, 0, None, None, False)
+    c = fetch.inspect_raw_cache_coverage("w", 10, 30)
+    assert not c.coverage_complete

--- a/sol_cgt/tests/test_compute_fetch.py
+++ b/sol_cgt/tests/test_compute_fetch.py
@@ -103,3 +103,24 @@ def test_no_fetch_fails_on_incomplete_cache_coverage(monkeypatch) -> None:
         assert False, "expected failure"
     except Exception as exc:
         assert "incomplete" in str(exc).lower()
+
+
+def test_refresh_raw_cache_fetches_once_when_provider_checked(monkeypatch) -> None:
+    settings = AppSettings(wallets=["wallet"], api_keys=APIKeys(helius="key"))
+    states = iter([
+        cli.fetch_mod.CacheCoverage("wallet", "wallet.jsonl", True, 1, 20, 30, 10, 30, False, True, False, [{"start": 10, "end": 30, "reason": "missing_start"}], 0, [], None),
+        cli.fetch_mod.CacheCoverage("wallet", "wallet.jsonl", True, 1, 20, 30, 10, 30, False, True, True, [], 0, [{"checked_start": 10, "checked_end": 30, "exhausted": True}], "provider_checked_range"),
+    ])
+    monkeypatch.setattr(cli.fetch_mod, "inspect_raw_cache_coverage", lambda *args, **kwargs: next(states))
+    calls = {"n": 0}
+
+    async def fake_fetch_wallet(*args, **kwargs):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(cli.fetch_mod, "fetch_wallet", fake_fetch_wallet)
+    monkeypatch.setattr(cli.fetch_mod, "load_cached", lambda _: [])
+    monkeypatch.setattr(cli.fetch_mod, "get_provider_checked_ranges", lambda _: [{"provider": "enhanced", "checked_start": 10, "checked_end": 30, "exhausted": True, "rows_returned": 0, "unique_signatures": 0, "earliest_returned_timestamp": None, "latest_returned_timestamp": None}])
+    complete, _ = cli._ensure_cache_coverage(["wallet"], gte_time=10, lte_time=30, fetch=True, settings=settings, refresh_raw_cache=True)
+    assert complete
+    assert calls["n"] == 1


### PR DESCRIPTION
### Motivation
- The cache coverage logic treated `cache_min_timestamp > requested_start` as incomplete even after a provider had exhaustively paginated the full requested range, causing repeated refetching loops.
- The intent is to record when a provider has checked (and exhausted) a requested window so absence of earlier transactions is provider-confirmed and can mark coverage complete.
- `--refresh-raw-cache` should fetch the full requested range once per wallet and not re-run coverage repair just because the earliest returned tx is later than the FY start.

### Description
- Added provider-checked range tracking with in-memory + persisted JSON metadata and helper functions `record_provider_checked_range` and `get_provider_checked_ranges` in `sol_cgt/ingestion/fetch.py` and a `PROVIDER_CHECKED_RANGES_PATH` file location.
- Make `fetch_wallet` record provider-checked range metadata (pages, rows, unique signatures, earliest/latest timestamps, and `exhausted`) when a full requested-range fetch completes.
- Update `inspect_raw_cache_coverage` to distinguish timestamp-span coverage from provider-verified coverage, set `coverage_complete_reason` to either `timestamp_span` or `provider_checked_range`, and consider an exhaustive provider-checked range as coverage-complete even if `cache_min_timestamp > requested_start`.
- Change refresh flow in `sol_cgt/cli.py` so `--refresh-raw-cache` performs a single full-range fetch per wallet, logs provider verification (`Raw provider range verified ... exhausted=...`), avoids looping re-fetches, and surface provider-checked fields in the reconciliation summary (e.g. `provider_checked_start`, `provider_checked_end`, `provider_exhausted`, `coverage_complete_reason`, `earliest_returned_timestamp`, `latest_returned_timestamp`).
- Updated and added unit tests in `sol_cgt/tests/test_cache_coverage.py` and `sol_cgt/tests/test_compute_fetch.py` to cover provider-checked exhaustive ranges (including zero-row exhaustion), non-exhaustive cases, and refresh-once behavior.

### Testing
- Added tests covering provider-checked exhaustive coverage with late earliest tx, provider-exhausted zero-rows, non-exhaustive provider checks not being complete, and refresh behavior preventing repeated fetches.
- Ran `pytest -q sol_cgt/tests/test_cache_coverage.py sol_cgt/tests/test_compute_fetch.py`, and the test run completed successfully.
- Modified files: `sol_cgt/ingestion/fetch.py`, `sol_cgt/cli.py`, `sol_cgt/tests/test_cache_coverage.py`, and `sol_cgt/tests/test_compute_fetch.py` as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab3410fc88331b2af64c17a97a16b)