### PR TITLE
Infer transfer-group swaps from SOL/WSOL/USDC/USDT anchors and exclude component legs

### DIFF
--- a/sol_cgt/accounting/eligibility.py
+++ b/sol_cgt/accounting/eligibility.py
@@ -67,6 +67,8 @@ def _classify_event(event: NormalizedEvent) -> None:
 
 
 def _policy_reason(event: NormalizedEvent, sol_dust_threshold: Decimal, aud_dust_threshold: Decimal, include_dust: bool) -> str | None:
+    if event.raw.get("swap_component"):
+        return "swap_component"
     if event.raw.get("manual_review_reason"):
         return str(event.raw["manual_review_reason"])
     if event.raw.get("accounting_action") in {"internal_transfer", "manual_review"}:

--- a/sol_cgt/ingestion/normalize.py
+++ b/sol_cgt/ingestion/normalize.py
@@ -16,6 +16,10 @@ from ..types import NormalizedEvent, TokenAmount
 
 LAMPORTS_PER_SOL = Decimal("1000000000")
 SOL_MINT = "SOL"
+WSOL_MINT = "So11111111111111111111111111111111111111112"
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+USDT_MINT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+ANCHOR_MINTS = {SOL_MINT, WSOL_MINT, USDC_MINT, USDT_MINT}
 LOGGER = logging.getLogger(__name__)
 
 
@@ -227,6 +231,106 @@ async def _build_swap_legs(
 def _attach_decimal_warning(raw: dict, token: TokenAmount, decimal_warning_mints: set[str]) -> None:
     if token.mint in decimal_warning_mints:
         raw["decimals_defaulted_mints"] = sorted({token.mint} | set(raw.get("decimals_defaulted_mints", [])))
+
+
+def _canonicalize_transfer_group_as_swap_if_possible(
+    tx_events: list[NormalizedEvent],
+    signature: str,
+    wallet: str,
+) -> list[NormalizedEvent]:
+    has_helius_swap = any(event.raw.get("source") == "helius_swap" for event in tx_events)
+    if has_helius_swap:
+        for event in tx_events:
+            if event.kind in {"transfer_in", "transfer_out"}:
+                event.raw["swap_component"] = True
+                event.raw["accounting_action"] = "component_of_helius_swap"
+                event.raw["classification"] = "swap_component"
+        return tx_events
+
+    net_by_mint: dict[str, Decimal] = {}
+    token_meta: dict[str, TokenAmount] = {}
+    for event in tx_events:
+        if event.wallet != wallet or event.kind not in {"transfer_in", "transfer_out"}:
+            continue
+        token = event.base_token or event.quote_token
+        if token is None:
+            continue
+        signed = token.amount if event.kind == "transfer_in" else -token.amount
+        net_by_mint[token.mint] = net_by_mint.get(token.mint, Decimal("0")) + signed
+        token_meta.setdefault(token.mint, token)
+
+    non_zero = {mint: amt for mint, amt in net_by_mint.items() if amt != 0}
+    non_anchor = {mint: amt for mint, amt in non_zero.items() if mint not in ANCHOR_MINTS}
+    anchor = {mint: amt for mint, amt in non_zero.items() if mint in ANCHOR_MINTS}
+    if len(non_anchor) != 1 or not anchor:
+        return tx_events
+
+    anchor_aud = Decimal("0")
+    usable_anchor = False
+    for event in tx_events:
+        if event.kind not in {"transfer_in", "transfer_out"}:
+            continue
+        token = event.base_token or event.quote_token
+        if token is None or token.mint not in ANCHOR_MINTS:
+            continue
+        hint = event.raw.get("proceeds_hint_aud") if event.kind == "transfer_out" else event.raw.get("cost_hint_aud")
+        if hint is None:
+            continue
+        usable_anchor = True
+        anchor_aud += Decimal(str(hint)) if event.kind == "transfer_out" else -Decimal(str(hint))
+    if not usable_anchor or anchor_aud == 0:
+        return tx_events
+
+    non_anchor_mint, non_anchor_delta = next(iter(non_anchor.items()))
+    if non_anchor_delta > 0 and anchor_aud > 0:
+        direction = "in"
+    elif non_anchor_delta < 0 and anchor_aud < 0:
+        direction = "out"
+    else:
+        return tx_events
+
+    for event in tx_events:
+        if event.kind in {"transfer_in", "transfer_out"}:
+            event.raw["swap_component"] = True
+            event.raw["accounting_action"] = "component_of_inferred_swap"
+            event.raw["classification"] = "swap_component"
+
+    ref_assets = [mint for mint in anchor.keys() if anchor[mint] != 0]
+    valuation_reference_asset = ref_assets[0] if len(ref_assets) == 1 else "mixed_anchor"
+    raw_payload = {
+        "source": "inferred_transfer_swap",
+        "signature": signature,
+        "swap_direction": direction,
+        "valuation_method": "inferred_from_transfer_group_anchor",
+        "valuation_reference_asset": valuation_reference_asset,
+        "valuation_confidence": "medium",
+    }
+    if len(ref_assets) == 1:
+        raw_payload["valuation_reference_amount"] = str(anchor[ref_assets[0]])
+    token = token_meta[non_anchor_mint]
+    normalized = TokenAmount(
+        mint=token.mint,
+        symbol=token.symbol,
+        decimals=token.decimals,
+        amount_raw=_amount_raw_from_decimal(abs(non_anchor_delta), token.decimals),
+    )
+    if direction == "in":
+        raw_payload["cost_hint_aud"] = str(anchor_aud.copy_abs())
+    else:
+        raw_payload["proceeds_hint_aud"] = str(anchor_aud.copy_abs())
+    inferred = NormalizedEvent(
+        id=f"{signature}:{wallet}#inferred_swap",
+        ts=tx_events[0].ts,
+        kind="swap",
+        base_token=normalized if direction == "out" else None,
+        quote_token=normalized if direction == "in" else None,
+        fee_sol=Decimal("0"),
+        wallet=wallet,
+        counterparty=None,
+        raw=raw_payload,
+        tags=set(),
+    )
+    return [*tx_events, inferred]
 
 def _collect_missing_mints(raw_txs: Iterable[dict]) -> set[str]:
     missing: set[str] = set()
@@ -523,6 +627,8 @@ async def normalize_wallet_events(
                     tags=set(),
                 )
             )
+
+        tx_events = _canonicalize_transfer_group_as_swap_if_possible(tx_events, signature, wallet)
 
         fee_assigned = False
         for event in tx_events:

--- a/sol_cgt/pricing/valuation.py
+++ b/sol_cgt/pricing/valuation.py
@@ -67,6 +67,8 @@ def valuate_events(events: Iterable[NormalizedEvent], ctx: ValuationContext) -> 
         if e.raw.get("valuation_method") == "missing_token_price_no_counterparty_leg"
     )
     ambiguous = sum(1 for e in events_list if e.raw.get("valuation_method") == "ambiguous_multi_token_swap")
+    inferred_transfer_swap_count = sum(1 for e in events_list if e.raw.get("source") == "inferred_transfer_swap")
+    inferred_transfer_swap_component_events = sum(1 for e in events_list if e.raw.get("accounting_action") == "component_of_inferred_swap")
     LOGGER.info("Inferred swap valuations from SOL legs count=%s", inferred)
     missing_mints = sorted(
         {
@@ -77,6 +79,9 @@ def valuate_events(events: Iterable[NormalizedEvent], ctx: ValuationContext) -> 
     )
     LOGGER.info("Missing token prices without counterparty leg count=%s unique_mints=%s", missing_no_leg, len(missing_mints))
     LOGGER.info("Ambiguous swap valuations count=%s", ambiguous)
+    LOGGER.info("inferred_transfer_swap_count=%s", inferred_transfer_swap_count)
+    LOGGER.info("inferred_transfer_swap_component_events=%s", inferred_transfer_swap_component_events)
+    LOGGER.info("remaining_missing_token_price_no_counterparty_leg=%s", missing_no_leg)
     return ctx.warnings
 
 

--- a/sol_cgt/reporting/summaries.py
+++ b/sol_cgt/reporting/summaries.py
@@ -124,10 +124,6 @@ def build_transaction_summary(events: Iterable[NormalizedEvent]) -> list[dict[st
         kinds = {e.kind for e in sig_events}
         has_trade = "swap" in kinds or any("swap" in str(e.raw.get("classification", "")) for e in sig_events)
         if has_trade:
-            for event in sig_events:
-                if event.kind in {"transfer_in", "transfer_out", "transfer_internal"}:
-                    event.raw["swap_component"] = True
-        if has_trade:
             classification = "trade"
         elif any(e.raw.get("accounting_action") == "manual_review" or e.raw.get("manual_review_reason") for e in sig_events):
             classification = "mixed_or_ambiguous"

--- a/sol_cgt/tests/test_reconciliation_signature_level.py
+++ b/sol_cgt/tests/test_reconciliation_signature_level.py
@@ -18,7 +18,7 @@ def test_signature_level_trade_classification_with_swap_plus_transfer() -> None:
     rows = summaries.build_transaction_summary(evs)
     assert len(rows) == 1
     assert rows[0]["classification"] == "trade"
-    assert evs[1].raw.get("swap_component") is True
+    assert evs[1].raw.get("swap_component") is None
 
 
 def test_reconciliation_counts_signature_level_not_event_level() -> None:

--- a/sol_cgt/tests/test_swap_canonicalization.py
+++ b/sol_cgt/tests/test_swap_canonicalization.py
@@ -4,6 +4,7 @@ import asyncio
 from decimal import Decimal
 
 from sol_cgt.ingestion import normalize
+from sol_cgt.accounting.eligibility import apply_accounting_policy
 
 
 def test_routed_swap_canonicalization(tmp_path) -> None:
@@ -82,3 +83,64 @@ def test_routed_swap_canonicalization(tmp_path) -> None:
         "TOKENC": Decimal("7"),
         "TOKEND": Decimal("1"),
     }
+
+
+def test_infer_buy_from_transfer_group_anchor(tmp_path) -> None:
+    tx = {
+        "signature": "sigbuy",
+        "timestamp": 1700000001,
+        "tokenTransfers": [
+            {"mint": "TOKENX", "tokenAmount": "100", "tokenDecimals": 6, "tokenSymbol": "TKX", "fromUserAccount": "POOL", "toUserAccount": "WALLET"},
+        ],
+        "nativeTransfers": [
+            {"amount": 1_000_000_000, "fromUserAccount": "WALLET", "toUserAccount": "POOL"},
+            {"amount": 1_000, "fromUserAccount": "WALLET", "toUserAccount": "RENT"},
+        ],
+    }
+    evs = asyncio.run(normalize.normalize_wallet_events("WALLET", [tx], mint_cache_path=tmp_path / "mint_meta.json"))
+    for ev in evs:
+        if ev.kind == "transfer_out" and (ev.base_token and ev.base_token.mint == "SOL"):
+            ev.raw["proceeds_hint_aud"] = "40" if ev.base_token.amount > Decimal("0.1") else "0"
+    evs = normalize._canonicalize_transfer_group_as_swap_if_possible(evs, "sigbuy", "WALLET")
+    inferred = [e for e in evs if e.raw.get("source") == "inferred_transfer_swap"]
+    assert len(inferred) == 1
+    assert inferred[0].quote_token is not None
+    assert inferred[0].raw.get("cost_hint_aud") == "40"
+    res = apply_accounting_policy(evs, sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len([e for e in res.taxable_events if e.raw.get("source") == "inferred_transfer_swap"]) == 1
+    assert any(r["reason"] == "swap_component" for r in res.manual_review)
+
+
+def test_infer_sell_from_transfer_group_anchor(tmp_path) -> None:
+    tx = {
+        "signature": "sigsell",
+        "timestamp": 1700000002,
+        "tokenTransfers": [
+            {"mint": "TOKENY", "tokenAmount": "50", "tokenDecimals": 6, "tokenSymbol": "TKY", "fromUserAccount": "WALLET", "toUserAccount": "POOL"},
+        ],
+        "nativeTransfers": [
+            {"amount": 500_000_000, "fromUserAccount": "POOL", "toUserAccount": "WALLET"},
+        ],
+    }
+    evs = asyncio.run(normalize.normalize_wallet_events("WALLET", [tx], mint_cache_path=tmp_path / "mint_meta.json"))
+    for ev in evs:
+        if ev.kind == "transfer_in" and (ev.quote_token and ev.quote_token.mint == "SOL"):
+            ev.raw["cost_hint_aud"] = "25"
+    evs = normalize._canonicalize_transfer_group_as_swap_if_possible(evs, "sigsell", "WALLET")
+    inferred = [e for e in evs if e.raw.get("source") == "inferred_transfer_swap"]
+    assert len(inferred) == 1
+    assert inferred[0].base_token is not None
+    assert inferred[0].raw.get("proceeds_hint_aud") == "25"
+
+
+def test_multi_non_anchor_remains_manual_review(tmp_path) -> None:
+    tx = {
+        "signature": "sigmulti",
+        "timestamp": 1700000003,
+        "tokenTransfers": [
+            {"mint": "T1", "tokenAmount": "1", "tokenDecimals": 6, "fromUserAccount": "POOL", "toUserAccount": "WALLET"},
+            {"mint": "T2", "tokenAmount": "1", "tokenDecimals": 6, "fromUserAccount": "WALLET", "toUserAccount": "POOL"},
+        ],
+    }
+    evs = asyncio.run(normalize.normalize_wallet_events("WALLET", [tx], mint_cache_path=tmp_path / "mint_meta.json"))
+    assert not any(e.raw.get("source") == "inferred_transfer_swap" for e in evs)

--- a/sol_cgt/tests/test_valuation.py
+++ b/sol_cgt/tests/test_valuation.py
@@ -134,3 +134,26 @@ def test_ambiguous_multi_token_swap_warns() -> None:
     assert warnings
     assert warnings[0].code == "ambiguous_multi_token_swap"
     assert event.raw["valuation_method"] == "ambiguous_multi_token_swap"
+
+
+def test_inferred_transfer_swap_with_anchor_hint_avoids_missing_price_warning() -> None:
+    ts = datetime(2024, 7, 2, tzinfo=timezone.utc)
+    event = NormalizedEvent(
+        id="sig3#1",
+        ts=ts,
+        kind="swap",
+        quote_token=TokenAmount(mint="TOKENQ", symbol="TKQ", decimals=6, amount_raw=1_000_000),
+        fee_sol=Decimal("0"),
+        wallet="WALLET",
+        raw={
+            "signature": "sig3",
+            "source": "inferred_transfer_swap",
+            "cost_hint_aud": "12.34",
+        },
+    )
+    ctx = valuation_module.ValuationContext(
+        usd_provider=TimestampPriceProvider(api_key=None),
+        fx_rate=lambda _: Decimal("1.0"),
+    )
+    warnings = valuation_module.valuate_events([event], ctx)
+    assert not any(w.code == "missing_token_price_no_counterparty_leg" for w in warnings)


### PR DESCRIPTION
### Motivation
- Transactions from Helius often include token/native transfer legs without a canonical `events.swap`, causing many `missing_token_price_no_counterparty_leg` valuations; most such groups contain SOL/WSOL or stablecoin value in the same signature that can be used as an anchor for valuation.  
- Avoid adding generic price lookups; instead infer transaction-implied valuation by canonicalizing transfer groups into a single swap when safe to do so.  
- Ensure inferred swaps are treated as taxable while marking underlying transfer legs as swap components so they are not independently taxed or cause missing-price warnings.

### Description
- Added `_canonicalize_transfer_group_as_swap_if_possible(tx_events, signature, wallet)` in `sol_cgt/ingestion/normalize.py` which: computes net wallet deltas per mint within a signature+wallet, recognizes anchor mints (`SOL`, WSOL, USDC, USDT), uses existing `proceeds_hint_aud`/`cost_hint_aud` hints on anchor legs, and infers a canonical `swap` event when exactly one non-anchor mint has a non-zero net and at least one anchor mint provides usable AUD net value.  
- The inferred swap preserves token mint/amount/decimals/symbol and sets `source=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabc3670ec8331b5be2e1b04027b57)