### PR TITLE
Preserve low-price token cost basis with high-precision unit costs

### DIFF
--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -419,7 +419,7 @@ class AccountingEngine:
             else:
                 total_cost = utils.quantize_aud(price * qty)
         lot_fee = fee_aud if event.base_token is None else Decimal("0")
-        unit_cost = utils.quantize_aud(total_cost / qty) if qty != 0 else Decimal("0")
+        unit_cost = utils.quantize_unit_cost_aud(total_cost / qty) if qty != 0 else Decimal("0")
         lot = AcquisitionLot(
             lot_id=f"{event.id}:{quote.mint}",
             wallet=event.wallet,

--- a/sol_cgt/reporting/xlsx.py
+++ b/sol_cgt/reporting/xlsx.py
@@ -283,7 +283,7 @@ def export_xlsx(
         for row in lot_rows:
             lots_sheet.append(list(row.values()))
         _apply_header_style(lots_sheet)
-        _format_numbers(lots_sheet, ["unit_cost_aud"], "#,##0.00")
+        _format_numbers(lots_sheet, ["unit_cost_aud"], "#,##0.000000000000")
         _format_numbers(lots_sheet, ["remaining_qty", "qty_acquired"], "#,##0.000000000")
         _auto_width(lots_sheet)
 

--- a/sol_cgt/tests/test_engine.py
+++ b/sol_cgt/tests/test_engine.py
@@ -113,3 +113,63 @@ def test_hifo_prefers_high_cost():
     disposals = engine.process([lot1, lot2, disposal]).disposals
     assert len(disposals) == 1
     assert disposals[0].cost_base_aud == Decimal("150.00")
+
+
+def test_low_unit_price_cost_basis_preserved_full_disposal() -> None:
+    ts1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts2 = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    wallet = "W3"
+    qty_raw = 358_099_601_641
+    acquisition = _event(
+        "lp1#0",
+        "buy",
+        ts=ts1,
+        wallet=wallet,
+        quote=_token("LOW", qty_raw, decimals=6, symbol="LOW"),
+        raw={"cost_aud": "42.33"},
+    )
+    disposal = _event(
+        "lp2#0",
+        "sell",
+        ts=ts2,
+        wallet=wallet,
+        base=_token("LOW", qty_raw, decimals=6, symbol="LOW"),
+        raw={"proceeds_aud": "39.54"},
+    )
+
+    result = AccountingEngine(price_provider=SimplePriceProvider({"SOL": Decimal("0")})).process([acquisition, disposal])
+    assert result.acquisitions[0].unit_cost_aud > Decimal("0")
+    assert len(result.disposals) == 1
+    assert result.disposals[0].cost_base_aud == Decimal("42.33")
+
+
+def test_low_unit_price_cost_basis_preserved_partial_disposal() -> None:
+    ts1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts2 = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    wallet = "W4"
+    qty_raw = 358_099_601_641
+    sold_raw = qty_raw // 2
+    qty = Decimal(qty_raw) / Decimal("1000000")
+    sold_qty = Decimal(sold_raw) / Decimal("1000000")
+    expected_cost_base = (Decimal("42.33") * sold_qty / qty).quantize(Decimal("0.01"))
+
+    acquisition = _event(
+        "pp1#0",
+        "buy",
+        ts=ts1,
+        wallet=wallet,
+        quote=_token("LOW", qty_raw, decimals=6, symbol="LOW"),
+        raw={"cost_aud": "42.33"},
+    )
+    disposal = _event(
+        "pp2#0",
+        "sell",
+        ts=ts2,
+        wallet=wallet,
+        base=_token("LOW", sold_raw, decimals=6, symbol="LOW"),
+        raw={"proceeds_aud": "20.00"},
+    )
+
+    result = AccountingEngine(price_provider=SimplePriceProvider({"SOL": Decimal("0")})).process([acquisition, disposal])
+    assert len(result.disposals) == 1
+    assert result.disposals[0].cost_base_aud == expected_cost_base

--- a/sol_cgt/tests/test_reporting_outputs.py
+++ b/sol_cgt/tests/test_reporting_outputs.py
@@ -138,6 +138,9 @@ def test_csv_and_xlsx_outputs(tmp_path) -> None:
     tx_headers = [cell.value for cell in workbook["Transactions"][1]]
     assert "valuation_method" in tx_headers
     assert "valuation_reference_asset" in tx_headers
+    lots_headers = [cell.value for cell in workbook["Lots"][1]]
+    unit_cost_col = lots_headers.index("unit_cost_aud") + 1
+    assert workbook["Lots"].cell(row=2, column=unit_cost_col).number_format == "#,##0.000000000000"
 
 
 def test_parquet_requires_extra(monkeypatch, tmp_path) -> None:

--- a/sol_cgt/utils.py
+++ b/sol_cgt/utils.py
@@ -128,6 +128,10 @@ def quantize_aud(value: Decimal) -> Decimal:
     return value.quantize(Decimal("0.01"))
 
 
+def quantize_unit_cost_aud(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.000000000001"))
+
+
 def chunked(seq: Sequence[Any], size: int) -> Iterator[Sequence[Any]]:
     for idx in range(0, len(seq), size):
         yield seq[idx : idx + size]


### PR DESCRIPTION
### Motivation
- Per-unit acquisition costs were quantized to cents with `quantize_aud`, which truncated unit costs for high-supply low-price tokens to `0.00` and produced incorrect disposal cost bases.
- The fix introduces higher internal precision for per-unit costs while keeping final reportable AUD values rounded to cents.

### Description
- Added `quantize_unit_cost_aud` in `sol_cgt/utils.py` that quantizes to 12 decimal places (`Decimal("0.000000000001")`) and left `quantize_aud` unchanged.
- Updated acquisition lot creation in `sol_cgt/accounting/engine.py` to use `quantize_unit_cost_aud(total_cost / qty)` so per-unit costs are not truncated to cents.
- Kept disposal cost-base rounding at the extended-cost level using `quantize_aud(lot.unit_cost_aud * qty_used)` so totals remain cent-rounded.
- Updated XLSX formatting in `sol_cgt/reporting/xlsx.py` to display `unit_cost_aud` with high precision (`"#,##0.000000000000"`) and added an XLSX test assertion for that format.
- Added regression tests in `sol_cgt/tests/test_engine.py` to check that a large-quantity low-price token creates a non-zero `unit_cost_aud`, that a full disposal yields `cost_base_aud == 42.33`, and that a partial disposal preserves proportional cost base.

### Testing
- Ran `pytest -q sol_cgt/tests/test_engine.py sol_cgt/tests/test_reporting_outputs.py`, and all tests passed (`.` output indicates success for those suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac5a523108331b4385bdcf2315b56)