### PR TITLE
Fix valued transfer-group accounting precedence and partial disposal shortfalls

### DIFF
--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -90,6 +90,11 @@ class AccountingEngine:
         swap_hint_warned: set[str] = set()
         default_decimals_warned: set[tuple[Optional[str], str]] = set()
         missing_price_warned: set[tuple[str, str, str]] = set()
+        self.debug_counters: dict[str, int] = {
+            "valued_transfer_group_acquisitions_accounted": 0,
+            "valued_transfer_group_disposals_accounted": 0,
+            "valued_transfer_group_events_routed_to_external_move": 0,
+        }
 
         for event in sorted(events, key=lambda ev: (ev.ts, ev.id)):
             if event.raw.get("is_internal_transfer_duplicate"):
@@ -139,43 +144,53 @@ class AccountingEngine:
                     raise
             if event.kind == "transfer_out" and event.base_token is not None:
                 if not event.counterparty or event.counterparty not in wallet_set:
-                    move_record, moved_lots = self._handle_out_of_scope_transfer(
-                        event,
-                        warnings,
-                        missing_price_warned,
-                        external_lot_tracking,
-                    )
-                    if move_record is not None:
-                        lot_moves.append(move_record)
-                    acquisitions.extend(moved_lots)
-                    continue
-            if event.kind == "transfer_in" and event.quote_token is not None:
-                if not event.counterparty or event.counterparty not in wallet_set:
-                    moved = False
-                    if external_lot_tracking:
-                        moved, moved_lots = self._handle_external_return(
+                    if self._should_force_taxable_disposal(event):
+                        self.debug_counters["valued_transfer_group_disposals_accounted"] += 1
+                    else:
+                        if self._is_valued_transfer_group_event(event):
+                            self.debug_counters["valued_transfer_group_events_routed_to_external_move"] += 1
+                        move_record, moved_lots = self._handle_out_of_scope_transfer(
                             event,
-                            lot_moves,
                             warnings,
                             missing_price_warned,
+                            external_lot_tracking,
                         )
-                        if moved:
-                            acquisitions.extend(moved_lots)
-                            continue
-                    warnings.append(
-                        WarningRecord(
-                            ts=event.ts,
-                            wallet=event.wallet,
-                            signature=event.raw.get("signature"),
-                            code="external_transfer_in",
-                            message=(
-                                "Transfer in from external wallet treated as acquisition at spot price."
-                                if external_lot_tracking
-                                else "Transfer in from external wallet treated as acquisition at spot price. "
-                                "Enable external_lot_tracking to attempt matching."
-                            ),
+                        if move_record is not None:
+                            lot_moves.append(move_record)
+                        acquisitions.extend(moved_lots)
+                        continue
+            if event.kind == "transfer_in" and event.quote_token is not None:
+                if not event.counterparty or event.counterparty not in wallet_set:
+                    if self._should_force_taxable_acquisition(event):
+                        self.debug_counters["valued_transfer_group_acquisitions_accounted"] += 1
+                    else:
+                        if self._is_valued_transfer_group_event(event):
+                            self.debug_counters["valued_transfer_group_events_routed_to_external_move"] += 1
+                        moved = False
+                        if external_lot_tracking:
+                            moved, moved_lots = self._handle_external_return(
+                                event,
+                                lot_moves,
+                                warnings,
+                                missing_price_warned,
+                            )
+                            if moved:
+                                acquisitions.extend(moved_lots)
+                                continue
+                        warnings.append(
+                            WarningRecord(
+                                ts=event.ts,
+                                wallet=event.wallet,
+                                signature=event.raw.get("signature"),
+                                code="external_transfer_in",
+                                message=(
+                                    "Transfer in from external wallet treated as acquisition at spot price."
+                                    if external_lot_tracking
+                                    else "Transfer in from external wallet treated as acquisition at spot price. "
+                                    "Enable external_lot_tracking to attempt matching."
+                                ),
+                            )
                         )
-                    )
             if event.kind == "swap":
                 signature = event.raw.get("signature")
                 if signature and event.raw.get("swap_hint_missing") and signature not in swap_hint_warned:
@@ -229,6 +244,26 @@ class AccountingEngine:
                     )
                 except methods.LotSelectionError as exc:
                     issue = exc.issue
+                    if issue is not None and issue.available_qty > 0 and issue.available_qty < issue.required_qty:
+                        partial_records = self._attempt_partial_disposal(event, base_token, proceeds_aud, fee_aud, issue)
+                        if partial_records:
+                            disposals.extend(partial_records)
+                            if missing_lot_issues is not None:
+                                missing_lot_issues.append(issue)
+                            warnings.append(
+                                WarningRecord(
+                                    ts=event.ts,
+                                    wallet=event.wallet,
+                                    signature=event.raw.get("signature"),
+                                    code="missing_lot_history",
+                                    message=(
+                                        "Partial disposal processed due to missing lot history "
+                                        f"(missing_qty={issue.shortfall_qty}, disposed_qty={issue.available_qty}, "
+                                        f"signature={event.raw.get('signature')})."
+                                    ),
+                                )
+                            )
+                            continue
                     if issue and missing_lot_issues is not None:
                         missing_lot_issues.append(issue)
                     if strict_lots:
@@ -272,6 +307,27 @@ class AccountingEngine:
             disposals=disposals,
             lot_moves=lot_moves,
             warnings=warnings,
+        )
+
+    def _is_valued_transfer_group_event(self, event: NormalizedEvent) -> bool:
+        return (
+            event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+            and event.raw.get("source") == "helius_token_transfer"
+            and not event.raw.get("swap_component")
+        )
+
+    def _should_force_taxable_disposal(self, event: NormalizedEvent) -> bool:
+        return (
+            not event.raw.get("swap_component")
+            and event.raw.get("accounting_action") == "taxable_disposal"
+            and event.raw.get("proceeds_hint_aud") is not None
+        )
+
+    def _should_force_taxable_acquisition(self, event: NormalizedEvent) -> bool:
+        return (
+            not event.raw.get("swap_component")
+            and event.raw.get("accounting_action") == "taxable_acquisition"
+            and event.raw.get("cost_hint_aud") is not None
         )
 
     # ------------------------------------------------------------------
@@ -723,6 +779,20 @@ class AccountingEngine:
     def _external_wallet_id(self, counterparty: Optional[str]) -> str:
         address = counterparty or "unknown"
         return f"__external__:{address}"
+
+    def _attempt_partial_disposal(
+        self,
+        event: NormalizedEvent,
+        base: TokenAmount,
+        proceeds_aud: Decimal,
+        fee_aud: Decimal,
+        issue: MissingLotIssue,
+    ) -> List[DisposalRecord]:
+        if issue.available_qty <= 0 or base.amount <= 0:
+            return []
+        partial_proceeds = utils.quantize_aud(proceeds_aud * (issue.available_qty / base.amount))
+        partial_fee = utils.quantize_aud(fee_aud * (issue.available_qty / base.amount))
+        return self._handle_disposal(event, base.model_copy(update={"amount": issue.available_qty}), partial_proceeds, partial_fee)
 
 
 def _issue_context(event: NormalizedEvent, token: TokenAmount) -> dict[str, object]:

--- a/sol_cgt/tests/test_engine.py
+++ b/sol_cgt/tests/test_engine.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 from sol_cgt.accounting.engine import AccountingEngine, SimplePriceProvider
-from sol_cgt.types import NormalizedEvent, TokenAmount
+from sol_cgt.types import MissingLotIssue, NormalizedEvent, TokenAmount
 
 
 def _token(mint: str, amount: int, decimals: int = 0, symbol: str | None = None) -> TokenAmount:
@@ -173,3 +173,53 @@ def test_low_unit_price_cost_basis_preserved_partial_disposal() -> None:
     result = AccountingEngine(price_provider=SimplePriceProvider({"SOL": Decimal("0")})).process([acquisition, disposal])
     assert len(result.disposals) == 1
     assert result.disposals[0].cost_base_aud == expected_cost_base
+
+
+def _token(mint: str, amount: int, decimals: int = 0, symbol: str | None = None) -> TokenAmount:
+    return TokenAmount(mint=mint, amount_raw=amount, decimals=decimals, symbol=symbol)
+
+
+def _ev(event_id: str, kind: str, ts: datetime, wallet: str, *, base=None, quote=None, counterparty=None, raw=None) -> NormalizedEvent:
+    payload = {"signature": event_id.split("#")[0]}
+    if raw:
+        payload.update(raw)
+    return NormalizedEvent(id=event_id, ts=ts, kind=kind, wallet=wallet, base_token=base, quote_token=quote, counterparty=counterparty, fee_sol=Decimal("0"), raw=payload, tags=set())
+
+
+def test_valued_transfer_out_routes_to_taxable_disposal_not_external_move() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    buy = _ev("b#0", "buy", ts, "W1", quote=_token("ABC", 10, symbol="ABC"), raw={"cost_aud": "100"})
+    sell = _ev("s#0", "transfer_out", ts.replace(hour=1), "W1", base=_token("ABC", 4, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_disposal", "proceeds_hint_aud": "80", "valuation_method": "inferred_from_same_signature_anchor", "source": "helius_token_transfer"})
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([buy, sell], wallets=["W1"])
+    assert len(result.disposals) == 1
+    assert len(result.lot_moves) == 0
+
+
+def test_valued_transfer_in_routes_to_taxable_acquisition_with_hint_cost() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    event = _ev("a#0", "transfer_in", ts, "W1", quote=_token("ABC", 5, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_acquisition", "cost_hint_aud": "55", "valuation_method": "inferred_from_same_signature_anchor", "source": "helius_token_transfer"})
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([event], wallets=["W1"], external_lot_tracking=True)
+    assert len(result.acquisitions) == 1
+    assert result.acquisitions[0].unit_cost_aud == Decimal("11.000000000000")
+    assert len(result.lot_moves) == 0
+
+
+def test_swap_component_transfer_row_remains_excluded_from_taxable() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    event = _ev("c#0", "transfer_in", ts, "W1", quote=_token("WSOL", 5, symbol="WSOL"), counterparty="EXT", raw={"accounting_action": "taxable_acquisition", "cost_hint_aud": "55", "swap_component": True, "valuation_method": "inferred_from_same_signature_anchor", "source": "helius_token_transfer"})
+    engine = AccountingEngine(price_provider=SimplePriceProvider({}))
+    result = engine.process([event], wallets=["W1"])
+    assert engine.debug_counters["valued_transfer_group_acquisitions_accounted"] == 0
+    assert len(result.acquisitions) == 1
+    assert len(result.lot_moves) == 0
+
+
+def test_partial_missing_lot_disposal_processes_available_amount() -> None:
+    ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    buy = _ev("p1#0", "buy", ts, "W1", quote=_token("ABC", 10, symbol="ABC"), raw={"cost_aud": "100"})
+    sell = _ev("p2#0", "sell", ts.replace(hour=1), "W1", base=_token("ABC", 12, symbol="ABC"), raw={"proceeds_aud": "120", "signature": "sigp2"})
+    issues: list[MissingLotIssue] = []
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([buy, sell], strict_lots=False, missing_lot_issues=issues)
+    assert len(result.disposals) == 1
+    assert result.disposals[0].qty_disposed == Decimal("10")
+    assert issues and issues[0].shortfall_qty == Decimal("2")


### PR DESCRIPTION
### Motivation
- Valued transfer-group swap events inferred by the valuation layer were being routed through external transfer handling, losing the inferred AUD cost/proceeds and preserving stale external lot costs instead of being treated as taxable acquisitions/disposals.
- The fix must be generic (no hardcoded wallets/signatures/mints/amounts) and preserve existing internal-transfer and swap-component exclusions.
- There was an all-or-nothing missing-lot exclusion bug that prevented partial disposals when only a small shortfall existed and should be handled more gracefully.

### Description
- Adjusted routing in `sol_cgt/accounting/engine.py` to check the event `raw["accounting_action"]` and the presence of a usable `cost_hint_aud`/`proceeds_hint_aud` before treating transfers as external lot moves, so valued transfer-group events are processed as taxable acquisitions/disposals when appropriate.
- Added helper predicates `
  _is_valued_transfer_group_event`, `
  _should_force_taxable_disposal`, and `
  _should_force_taxable_acquisition` to implement the gating while preserving `raw["swap_component"]` exclusions.
- Implemented partial-disposal handling via `_attempt_partial_disposal` so that when inventory is insufficient but non-zero the available lots are disposed and a missing-lot issue/warning is emitted for the shortfall instead of excluding the whole event.
- Added debug counters on the engine instance: `valued_transfer_group_acquisitions_accounted`, `valued_transfer_group_disposals_accounted`, and `valued_transfer_group_events_routed_to_external_move` and wired them into the new routing logic.
- Updated tests in `sol_cgt/tests/test_engine.py` with regression cases covering valued `transfer_out` taxable disposals, valued `transfer_in` taxable acquisitions using `cost_hint_aud`, `swap_component` exclusion, and partial missing-lot disposal behavior.

### Testing
- Ran targeted pytest cases: `test_valued_transfer_out_routes_to_taxable_disposal_not_external_move`, `test_valued_transfer_in_routes_to_taxable_acquisition_with_hint_cost`, `test_swap_component_transfer_row_remains_excluded_from_taxable`, `test_partial_missing_lot_disposal_processes_available_amount`, `test_self_transfer_lot_move`, and `test_out_of_scope_transfer_allocates_fees`, and all tests passed.
- The new regression tests exercise both valued-transfer routing and partial-disposal behaviour and confirmed that previously misrouted valued transfers now become taxable acquisitions/disposals and that partial shortfalls dispose available quantity while emitting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac8cc60e4833187de68838e61ba59)