### PR TITLE
Refine transfer-group classification for unanchored token-to-token swaps

### DIFF
--- a/sol_cgt/accounting/eligibility.py
+++ b/sol_cgt/accounting/eligibility.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Iterable
 
+from ..pricing.valuation import SOL_MINT, TRANSFER_ANCHOR_MINTS
+from ..pricing import WSOL_MINT, normalize_mint
 from ..types import NormalizedEvent
 
 
@@ -21,11 +23,13 @@ def apply_accounting_policy(
     aud_dust_threshold: Decimal,
     include_dust: bool,
 ) -> EligibilityResult:
+    events_list = list(events)
+    _classify_transfer_groups(events_list)
     taxable: list[NormalizedEvent] = []
     manual_review: list[dict[str, object]] = []
     dust_ignored: list[dict[str, object]] = []
 
-    for event in events:
+    for event in events_list:
         _classify_event(event)
         reason = _policy_reason(event, sol_dust_threshold, aud_dust_threshold, include_dust)
         if reason is None and event.raw.get("accounting_action") in {"taxable_acquisition", "taxable_disposal"} and not event.raw.get("swap_component"):
@@ -40,6 +44,48 @@ def apply_accounting_policy(
             manual_review.append(row)
 
     return EligibilityResult(taxable_events=taxable, manual_review=manual_review, dust_ignored=dust_ignored)
+
+
+def _classify_transfer_groups(events: list[NormalizedEvent]) -> None:
+    grouped: dict[tuple[str, str], list[NormalizedEvent]] = {}
+    for ev in events:
+        sig = ev.raw.get("signature")
+        if sig:
+            grouped.setdefault((sig, ev.wallet), []).append(ev)
+    anchor_mints = {normalize_mint(m) for m in TRANSFER_ANCHOR_MINTS}
+    for (_, _), group in grouped.items():
+        transfer_rows = [e for e in group if e.kind in {"transfer_in", "transfer_out"} and not e.raw.get("swap_component")]
+        if not transfer_rows:
+            continue
+        deltas: dict[str, Decimal] = {}
+        mint_events: dict[str, list[NormalizedEvent]] = {}
+        for ev in transfer_rows:
+            tok = ev.base_token if ev.kind == "transfer_out" else ev.quote_token
+            if tok is None:
+                continue
+            mint = normalize_mint(tok.mint)
+            if mint == normalize_mint(SOL_MINT) and tok.amount == 0:
+                continue
+            delta = tok.amount if ev.kind == "transfer_in" else -tok.amount
+            deltas[mint] = deltas.get(mint, Decimal("0")) + delta
+            mint_events.setdefault(mint, []).append(ev)
+        non_zero = {m: q for m, q in deltas.items() if q != 0}
+        non_anchor = {m: q for m, q in non_zero.items() if m not in anchor_mints}
+        anchor = {m: q for m, q in non_zero.items() if m in anchor_mints}
+        if not non_anchor:
+            continue
+        # Clean token-to-token: one non-anchor out and one non-anchor in with no anchor leg.
+        neg = [(m, q) for m, q in non_anchor.items() if q < 0]
+        pos = [(m, q) for m, q in non_anchor.items() if q > 0]
+        if len(anchor) == 0 and len(neg) == 1 and len(pos) == 1 and neg[0][0] != pos[0][0]:
+            for ev in transfer_rows:
+                ev.raw["swap_component"] = True
+                ev.raw["accounting_action"] = "component_of_token_to_token_swap"
+            continue
+        # Ambiguous unanchored/multi-leg transfer groups should not be forced taxable.
+        if len(anchor) == 0:
+            for ev in transfer_rows:
+                ev.raw.setdefault("manual_review_reason", "token_transfer_group_ambiguous")
 
 
 def _classify_event(event: NormalizedEvent) -> None:

--- a/sol_cgt/tests/test_accounting_eligibility.py
+++ b/sol_cgt/tests/test_accounting_eligibility.py
@@ -30,3 +30,23 @@ def test_missing_price_goes_manual_review():
     ev = _ev("buy", quote=_tok("UNSUPPORTED", 100), raw={"valuation_method": "missing_token_price_no_counterparty_leg", "unpriced": True})
     res = apply_accounting_policy([ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
     assert res.manual_review[0]["reason"] == "missing_token_price_no_counterparty_leg"
+
+
+def test_unanchored_token_to_token_group_marks_components_non_taxable():
+    out_ev = _ev("transfer_out", base=_tok("TOKA", 5, decimals=0), raw={"signature": "sig-1", "source": "helius_token_transfer"})
+    in_ev = _ev("transfer_in", quote=_tok("TOKB", 10, decimals=0), raw={"signature": "sig-1", "source": "helius_token_transfer"})
+    res = apply_accounting_policy([out_ev, in_ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len(res.taxable_events) == 0
+    assert out_ev.raw.get("swap_component") is True
+    assert in_ev.raw.get("swap_component") is True
+    assert out_ev.raw.get("accounting_action") == "manual_review"
+    assert in_ev.raw.get("accounting_action") == "manual_review"
+
+
+def test_unanchored_ambiguous_group_stays_manual_review():
+    a_out = _ev("transfer_out", base=_tok("TOKA", 5, decimals=0), raw={"signature": "sig-2"})
+    b_in = _ev("transfer_in", quote=_tok("TOKB", 3, decimals=0), raw={"signature": "sig-2"})
+    c_in = _ev("transfer_in", quote=_tok("TOKC", 2, decimals=0), raw={"signature": "sig-2"})
+    res = apply_accounting_policy([a_out, b_in, c_in], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len(res.taxable_events) == 0
+    assert len(res.manual_review) == 3


### PR DESCRIPTION
### Motivation
- Prevent false taxable events caused by treating individual transfer rows as independent when they are part of unanchored token-to-token swaps in the same signature/wallet.
- Avoid over-trusting per-row inferred anchors and make upstream ambiguous groups surface for manual review rather than producing artificial gains.

### Description
- Add a signature+wallet grouping pass (`_classify_transfer_groups`) executed before per-event eligibility to compute net wallet deltas per mint and analyze group structure.
- Grouping logic ignores existing `swap_component` rows and zero-amount native SOL noise, normalizes mint ids via `normalize_mint`, and treats `TRANSFER_ANCHOR_MINTS` as anchors.
- For clean unanchored token-to-token groups (one non-anchor net out and one non-anchor net in with no anchor), mark all transfer rows as `swap_component=True` and set `accounting_action` to `component_of_token_to_token_swap` to exclude them from independent taxable treatment.
- For unanchored ambiguous groups (multiple non-anchor legs or no clean pair), set a `manual_review_reason` (`token_transfer_group_ambiguous`) so rows remain manual-review and are not forced taxable.
- Files changed: `sol_cgt/accounting/eligibility.py` (classification pass + integration) and `sol_cgt/tests/test_accounting_eligibility.py` (new tests for unanchored token-to-token and ambiguous groups).

### Testing
- Ran `pytest -q sol_cgt/tests/test_accounting_eligibility.py` and it passed.
- Ran `pytest -q sol_cgt/tests/test_accounting_eligibility.py sol_cgt/tests/test_engine.py` and both test suites passed.
- New unit tests assert that unanchored token-to-token groups mark component rows and do not surface as taxable, and that ambiguous unanchored groups remain in manual review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69face15e43c83318a0a303889673c65)