### PR TITLE
Exclude medium-confidence same-signature Helius transfers from forced CGT accounting

### DIFF
--- a/sol_cgt/accounting/eligibility.py
+++ b/sol_cgt/accounting/eligibility.py
@@ -47,6 +47,16 @@ def apply_accounting_policy(
 
 
 def _classify_event(event: NormalizedEvent) -> None:
+    if (
+        event.raw.get("source") == "helius_token_transfer"
+        and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+        and event.raw.get("valuation_confidence") == "medium"
+        and event.kind in {"transfer_in", "transfer_out"}
+    ):
+        event.raw["classification"] = "inferred_transfer_manual_review"
+        event.raw["accounting_action"] = "manual_review"
+        event.raw.setdefault("manual_review_reason", "inferred_same_signature_anchor_medium_confidence")
+        return
     if event.raw.get("is_internal_transfer") or event.kind == "transfer_internal":
         event.raw["classification"] = "internal_transfer"
         event.raw["accounting_action"] = "internal_transfer"

--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -100,6 +100,10 @@ class AccountingEngine:
         for event in sorted(events_list, key=lambda ev: (ev.ts, ev.id)):
             if event.raw.get("is_internal_transfer_duplicate"):
                 continue
+            if self._is_medium_confidence_inferred_transfer(event):
+                event.raw["accounting_action"] = "manual_review"
+                event.raw.setdefault("manual_review_reason", "inferred_same_signature_anchor_medium_confidence")
+                continue
             if event.kind == "transfer_internal":
                 continue
             if event.id in matched_in_ids:
@@ -346,7 +350,21 @@ class AccountingEngine:
             and not event.raw.get("swap_component")
         )
 
+    def _is_medium_confidence_inferred_transfer(self, event: NormalizedEvent) -> bool:
+        return (
+            event.raw.get("source") == "helius_token_transfer"
+            and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+            and event.raw.get("valuation_confidence") == "medium"
+            and event.kind in {"transfer_in", "transfer_out"}
+        )
+
     def _should_force_taxable_disposal(self, event: NormalizedEvent) -> bool:
+        if (
+            event.raw.get("source") == "helius_token_transfer"
+            and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+            and event.raw.get("valuation_confidence") == "medium"
+        ):
+            return False
         return (
             not event.raw.get("swap_component")
             and event.raw.get("accounting_action") == "taxable_disposal"
@@ -354,6 +372,12 @@ class AccountingEngine:
         )
 
     def _should_force_taxable_acquisition(self, event: NormalizedEvent) -> bool:
+        if (
+            event.raw.get("source") == "helius_token_transfer"
+            and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+            and event.raw.get("valuation_confidence") == "medium"
+        ):
+            return False
         return (
             not event.raw.get("swap_component")
             and event.raw.get("accounting_action") == "taxable_acquisition"

--- a/sol_cgt/tests/test_accounting_eligibility.py
+++ b/sol_cgt/tests/test_accounting_eligibility.py
@@ -48,3 +48,37 @@ def test_unanchored_ambiguous_group_stays_manual_review():
     res = apply_accounting_policy([a_out, b_in, c_in], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
     assert len(res.taxable_events) == 0
     assert len(res.manual_review) == 3
+
+
+def test_medium_confidence_inferred_transfer_out_goes_manual_review_not_taxable():
+    ev = _ev(
+        "transfer_out",
+        base=_tok("abc", 1000),
+        raw={
+            "source": "helius_token_transfer",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+            "proceeds_hint_aud": "120.00",
+        },
+    )
+    res = apply_accounting_policy([ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len(res.taxable_events) == 0
+    assert len(res.manual_review) == 1
+    assert ev.raw["accounting_action"] == "manual_review"
+
+
+def test_medium_confidence_inferred_transfer_in_goes_manual_review_not_taxable():
+    ev = _ev(
+        "transfer_in",
+        quote=_tok("abc", 1000),
+        raw={
+            "source": "helius_token_transfer",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+            "cost_hint_aud": "120.00",
+        },
+    )
+    res = apply_accounting_policy([ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len(res.taxable_events) == 0
+    assert len(res.manual_review) == 1
+    assert ev.raw["accounting_action"] == "manual_review"

--- a/sol_cgt/tests/test_engine.py
+++ b/sol_cgt/tests/test_engine.py
@@ -186,22 +186,38 @@ def _ev(event_id: str, kind: str, ts: datetime, wallet: str, *, base=None, quote
     return NormalizedEvent(id=event_id, ts=ts, kind=kind, wallet=wallet, base_token=base, quote_token=quote, counterparty=counterparty, fee_sol=Decimal("0"), raw=payload, tags=set())
 
 
-def test_valued_transfer_out_routes_to_taxable_disposal_not_external_move() -> None:
+def test_medium_confidence_inferred_transfer_out_is_not_forced_taxable_disposal() -> None:
     ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
     buy = _ev("b#0", "buy", ts, "W1", quote=_token("ABC", 10, symbol="ABC"), raw={"cost_aud": "100"})
-    sell = _ev("s#0", "transfer_out", ts.replace(hour=1), "W1", base=_token("ABC", 4, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_disposal", "proceeds_hint_aud": "80", "valuation_method": "inferred_from_same_signature_anchor", "source": "helius_token_transfer"})
+    sell = _ev("s#0", "transfer_out", ts.replace(hour=1), "W1", base=_token("ABC", 4, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_disposal", "proceeds_hint_aud": "80", "valuation_method": "inferred_from_same_signature_anchor", "valuation_confidence": "medium", "source": "helius_token_transfer"})
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([buy, sell], wallets=["W1"])
+    assert len(result.disposals) == 0
+    assert len(result.lot_moves) == 0
+
+
+def test_medium_confidence_inferred_transfer_in_is_not_forced_taxable_acquisition() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    event = _ev("a#0", "transfer_in", ts, "W1", quote=_token("ABC", 5, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_acquisition", "cost_hint_aud": "55", "valuation_method": "inferred_from_same_signature_anchor", "valuation_confidence": "medium", "source": "helius_token_transfer"})
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([event], wallets=["W1"], external_lot_tracking=True)
+    assert len(result.acquisitions) == 0
+    assert len(result.lot_moves) == 0
+
+
+def test_high_confidence_inferred_transfer_out_is_still_forced_taxable_disposal() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    buy = _ev("b#0", "buy", ts, "W1", quote=_token("ABC", 10, symbol="ABC"), raw={"cost_aud": "100"})
+    sell = _ev("s#0", "transfer_out", ts.replace(hour=1), "W1", base=_token("ABC", 4, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_disposal", "proceeds_hint_aud": "80", "valuation_method": "inferred_from_same_signature_anchor", "valuation_confidence": "high", "source": "helius_token_transfer"})
     result = AccountingEngine(price_provider=SimplePriceProvider({})).process([buy, sell], wallets=["W1"])
     assert len(result.disposals) == 1
-    assert len(result.lot_moves) == 0
 
 
-def test_valued_transfer_in_routes_to_taxable_acquisition_with_hint_cost() -> None:
+def test_swap_event_remains_taxable() -> None:
     ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
-    event = _ev("a#0", "transfer_in", ts, "W1", quote=_token("ABC", 5, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_acquisition", "cost_hint_aud": "55", "valuation_method": "inferred_from_same_signature_anchor", "source": "helius_token_transfer"})
-    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([event], wallets=["W1"], external_lot_tracking=True)
-    assert len(result.acquisitions) == 1
-    assert result.acquisitions[0].unit_cost_aud == Decimal("11.000000000000")
-    assert len(result.lot_moves) == 0
+    buy = _ev("b#0", "buy", ts, "W1", quote=_token("ABC", 10, symbol="ABC"), raw={"cost_aud": "100"})
+    swap = _ev("sw#0", "swap", ts.replace(hour=1), "W1", base=_token("ABC", 4, symbol="ABC"), quote=_token("XYZ", 8, symbol="XYZ"), raw={"proceeds_hint_aud": "80", "cost_hint_aud": "80", "valuation_method": "canonical_swap"})
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([buy, swap], wallets=["W1"])
+    assert len(result.disposals) == 1
+    assert len(result.acquisitions) == 2
 
 
 def test_swap_component_transfer_row_remains_excluded_from_taxable() -> None:


### PR DESCRIPTION
### Motivation
- Medium-confidence (`valuation_confidence == "medium"`) same-signature anchor valuations from `helius_token_transfer` were being treated as authoritative proceeds/costs and forced into taxable disposals/acquisitions, inflating CGT outcomes.
- These inferred valuations should remain available as diagnostic hints but must not automatically create taxable CGT events; they should be routed to manual review instead.

### Description
- Added an early classification guard in `sol_cgt/accounting/eligibility.py` to mark `helius_token_transfer` events with `valuation_method == "inferred_from_same_signature_anchor"` and `valuation_confidence == "medium"` for `transfer_in`/`transfer_out` as `manual_review` with reason `inferred_same_signature_anchor_medium_confidence`.
- Introduced an engine-level early-skip (`_is_medium_confidence_inferred_transfer`) and applied it at the start of `AccountingEngine.process` to exclude these medium-confidence inferred transfer rows from direct disposal/acquisition accounting in `sol_cgt/accounting/engine.py`.
- Hardened `_should_force_taxable_disposal` and `_should_force_taxable_acquisition` to return `False` for these medium-confidence same-signature inferred Helius transfers so hint-based proceeds/costs do not force taxation.
- Preserved all valuation metadata/hints and existing swap/canonical logic; added/updated focused tests in `sol_cgt/tests/test_accounting_eligibility.py` and `sol_cgt/tests/test_engine.py` to cover medium-confidence behavior, high-confidence behavior, and canonical swaps.

### Testing
- Ran the targeted tests with `pytest -q sol_cgt/tests/test_accounting_eligibility.py sol_cgt/tests/test_engine.py` and the test run completed successfully (all tests passed).
- The changes are covered by new assertions that medium-confidence inferred `transfer_in`/`transfer_out` rows are routed to manual review and are not forced into taxable acquisitions/disposals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf7be5ad48331b3d442d30f569600)