### PR TITLE
Preserve medium-confidence Helius inferred `transfer_in` acquisitions while keeping `transfer_out` manual-review

### DIFF
--- a/sol_cgt/accounting/eligibility.py
+++ b/sol_cgt/accounting/eligibility.py
@@ -51,7 +51,7 @@ def _classify_event(event: NormalizedEvent) -> None:
         event.raw.get("source") == "helius_token_transfer"
         and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
         and event.raw.get("valuation_confidence") == "medium"
-        and event.kind in {"transfer_in", "transfer_out"}
+        and event.kind == "transfer_out"
     ):
         event.raw["classification"] = "inferred_transfer_manual_review"
         event.raw["accounting_action"] = "manual_review"

--- a/sol_cgt/accounting/engine.py
+++ b/sol_cgt/accounting/engine.py
@@ -100,7 +100,7 @@ class AccountingEngine:
         for event in sorted(events_list, key=lambda ev: (ev.ts, ev.id)):
             if event.raw.get("is_internal_transfer_duplicate"):
                 continue
-            if self._is_medium_confidence_inferred_transfer(event):
+            if self._is_medium_confidence_inferred_transfer_out(event):
                 event.raw["accounting_action"] = "manual_review"
                 event.raw.setdefault("manual_review_reason", "inferred_same_signature_anchor_medium_confidence")
                 continue
@@ -350,12 +350,12 @@ class AccountingEngine:
             and not event.raw.get("swap_component")
         )
 
-    def _is_medium_confidence_inferred_transfer(self, event: NormalizedEvent) -> bool:
+    def _is_medium_confidence_inferred_transfer_out(self, event: NormalizedEvent) -> bool:
         return (
             event.raw.get("source") == "helius_token_transfer"
             and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
             and event.raw.get("valuation_confidence") == "medium"
-            and event.kind in {"transfer_in", "transfer_out"}
+            and event.kind == "transfer_out"
         )
 
     def _should_force_taxable_disposal(self, event: NormalizedEvent) -> bool:
@@ -372,6 +372,17 @@ class AccountingEngine:
         )
 
     def _should_force_taxable_acquisition(self, event: NormalizedEvent) -> bool:
+        if (
+            event.raw.get("source") == "helius_token_transfer"
+            and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"
+            and event.raw.get("valuation_confidence") == "medium"
+            and event.kind == "transfer_in"
+            and event.raw.get("cost_hint_aud") is not None
+        ):
+            return (
+                not event.raw.get("swap_component")
+                and event.raw.get("accounting_action") == "taxable_acquisition"
+            )
         if (
             event.raw.get("source") == "helius_token_transfer"
             and event.raw.get("valuation_method") == "inferred_from_same_signature_anchor"

--- a/sol_cgt/tests/test_accounting_eligibility.py
+++ b/sol_cgt/tests/test_accounting_eligibility.py
@@ -67,7 +67,7 @@ def test_medium_confidence_inferred_transfer_out_goes_manual_review_not_taxable(
     assert ev.raw["accounting_action"] == "manual_review"
 
 
-def test_medium_confidence_inferred_transfer_in_goes_manual_review_not_taxable():
+def test_medium_confidence_inferred_transfer_in_with_cost_hint_stays_taxable():
     ev = _ev(
         "transfer_in",
         quote=_tok("abc", 1000),
@@ -79,6 +79,22 @@ def test_medium_confidence_inferred_transfer_in_goes_manual_review_not_taxable()
         },
     )
     res = apply_accounting_policy([ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
+    assert len(res.taxable_events) == 1
+    assert len(res.manual_review) == 0
+    assert ev.raw["accounting_action"] == "taxable_acquisition"
+
+
+def test_medium_confidence_inferred_transfer_in_without_cost_hint_goes_manual_review():
+    ev = _ev(
+        "transfer_in",
+        quote=_tok("abc", 1000),
+        raw={
+            "source": "helius_token_transfer",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+        },
+    )
+    res = apply_accounting_policy([ev], sol_dust_threshold=Decimal("0.00001"), aud_dust_threshold=Decimal("0.01"), include_dust=False)
     assert len(res.taxable_events) == 0
     assert len(res.manual_review) == 1
-    assert ev.raw["accounting_action"] == "manual_review"
+    assert res.manual_review[0]["reason"] == "external_transfer_in_unclassified"

--- a/sol_cgt/tests/test_engine.py
+++ b/sol_cgt/tests/test_engine.py
@@ -195,11 +195,11 @@ def test_medium_confidence_inferred_transfer_out_is_not_forced_taxable_disposal(
     assert len(result.lot_moves) == 0
 
 
-def test_medium_confidence_inferred_transfer_in_is_not_forced_taxable_acquisition() -> None:
+def test_medium_confidence_inferred_transfer_in_with_cost_hint_is_forced_taxable_acquisition() -> None:
     ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
     event = _ev("a#0", "transfer_in", ts, "W1", quote=_token("ABC", 5, symbol="ABC"), counterparty="EXT", raw={"accounting_action": "taxable_acquisition", "cost_hint_aud": "55", "valuation_method": "inferred_from_same_signature_anchor", "valuation_confidence": "medium", "source": "helius_token_transfer"})
     result = AccountingEngine(price_provider=SimplePriceProvider({})).process([event], wallets=["W1"], external_lot_tracking=True)
-    assert len(result.acquisitions) == 0
+    assert len(result.acquisitions) == 1
     assert len(result.lot_moves) == 0
 
 
@@ -228,6 +228,76 @@ def test_swap_component_transfer_row_remains_excluded_from_taxable() -> None:
     assert engine.debug_counters["valued_transfer_group_acquisitions_accounted"] == 0
     assert len(result.acquisitions) == 1
     assert len(result.lot_moves) == 0
+
+
+def test_medium_confidence_inferred_transfer_in_without_cost_hint_is_not_forced_taxable() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    event = _ev(
+        "a#1",
+        "transfer_in",
+        ts,
+        "W1",
+        quote=_token("ABC", 5, symbol="ABC"),
+        counterparty="EXT",
+        raw={
+            "accounting_action": "taxable_acquisition",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+            "source": "helius_token_transfer",
+        },
+    )
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([event], wallets=["W1"], external_lot_tracking=True)
+    assert len(result.acquisitions) == 1
+    assert len(result.lot_moves) == 0
+    assert result.acquisitions[0].unit_cost_aud == Decimal("0")
+
+
+def test_inferred_transfer_in_lot_is_consumed_and_inferred_transfer_out_is_not_disposal() -> None:
+    ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    inferred_in = _ev(
+        "i#0",
+        "transfer_in",
+        ts,
+        "W1",
+        quote=_token("ABC", 5, symbol="ABC"),
+        counterparty="EXT",
+        raw={
+            "accounting_action": "taxable_acquisition",
+            "cost_hint_aud": "55",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+            "source": "helius_token_transfer",
+        },
+    )
+    inferred_out = _ev(
+        "o#0",
+        "transfer_out",
+        ts.replace(hour=1),
+        "W1",
+        base=_token("ABC", 2, symbol="ABC"),
+        counterparty="EXT",
+        raw={
+            "accounting_action": "taxable_disposal",
+            "proceeds_hint_aud": "22",
+            "valuation_method": "inferred_from_same_signature_anchor",
+            "valuation_confidence": "medium",
+            "source": "helius_token_transfer",
+        },
+    )
+    swap = _ev(
+        "sw2#0",
+        "swap",
+        ts.replace(hour=2),
+        "W1",
+        base=_token("ABC", 5, symbol="ABC"),
+        quote=_token("XYZ", 10, symbol="XYZ"),
+        raw={"proceeds_hint_aud": "100", "cost_hint_aud": "100", "valuation_method": "canonical_swap"},
+    )
+
+    result = AccountingEngine(price_provider=SimplePriceProvider({})).process([inferred_in, inferred_out, swap], wallets=["W1"])
+    assert len(result.disposals) == 1
+    assert result.disposals[0].event_id == "sw2#0"
+    assert result.disposals[0].cost_base_aud == Decimal("55.00")
 
 
 def test_partial_missing_lot_disposal_processes_available_amount() -> None:


### PR DESCRIPTION
### Motivation
- Medium-confidence Helius same-signature inferred transfers were being blanket-routed to manual review, which wrongly excluded `transfer_in` rows with `cost_hint_aud` from seeding acquisition lots and thus lost cost-base history.
- The goal is to prevent inferred `transfer_out` proceeds from being treated as authoritative taxable disposals while still allowing priced inferred `transfer_in` rows to create acquisition lots.

### Description
- Narrowed the eligibility classifier in `eligibility.py` so only medium-confidence inferred Helius `transfer_out` events are auto-classified as `inferred_transfer_manual_review` (removed `transfer_in` from the blanket case).
- Replaced the engine early-skip guard with `_is_medium_confidence_inferred_transfer_out` in `engine.py` so only inferred `transfer_out` events are short-circuited to manual review during processing.
- Adjusted `_should_force_taxable_acquisition` in `engine.py` to allow medium-confidence Helius `transfer_in` events with `cost_hint_aud` to be treated as taxable acquisitions while keeping other medium-confidence inferred cases non-forced; left `_should_force_taxable_disposal` returning `False` for medium-confidence inferred rows to prevent forced taxable disposals.
- Preserved valuation metadata and relevant flags (`valuation_method`, `valuation_confidence`, `valuation_source`, `cost_hint_aud` / `proceeds_hint_aud`, and `manual_review_reason`) by not removing or overwriting them beyond classification changes.
- Updated and added tests under `sol_cgt/tests/` to assert the new behavior and regression shape.

### Testing
- Ran `pytest -q sol_cgt/tests/test_accounting_eligibility.py sol_cgt/tests/test_engine.py` and all tests passed.
- New/updated tests cover: medium-confidence inferred `transfer_out` -> manual review, medium-confidence inferred `transfer_in` with `cost_hint_aud` -> taxable acquisition, medium-confidence inferred `transfer_in` without `cost_hint_aud` -> manual review/missing price, canonical swap and swap-component behaviors, and a regression that ensures an inferred acquisition lot is consumed by a later real swap while inferred transfer-out does not create a disposal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafac382b48331a3823bf739792700)